### PR TITLE
Fix organization references in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ gmail-ro/
 │   ├── auto-release.yml        # Create tags on main push
 │   └── release.yml             # Build and release binaries
 ├── Makefile                    # Build, test, lint targets
-└── go.mod                      # Module: github.com/piekstra/gmail-ro
+└── go.mod                      # Module: github.com/open-cli-collective/gmail-ro
 ```
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ A read-only command-line interface for Gmail. Search, read, and view email threa
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew install piekstra/tap/gmail-ro
+brew tap open-cli-collective/tap
+brew install --cask gmail-ro
 ```
 
 ### Download Binary
 
-Download the latest release for your platform from the [Releases page](https://github.com/piekstra/gmail-ro/releases).
+Download the latest release for your platform from the [Releases page](https://github.com/open-cli-collective/gmail-ro/releases).
 
 ### Build from Source
 
 ```bash
-go install github.com/piekstra/gmail-ro@latest
+go install github.com/open-cli-collective/gmail-ro@latest
 ```
 
 ## Setup


### PR DESCRIPTION
## Summary
- Update Homebrew install instruction to use `open-cli-collective/tap`
- Update Releases page link to point to `open-cli-collective` org
- Update `go install` path to use `open-cli-collective` org
- Update CLAUDE.md module path reference

These references were outdated after the repo was moved to the open-cli-collective organization.