### PR TITLE
chore: add unified Claude Code settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go:*)",
+      "Bash(golangci-lint:*)",
+      "Bash(goimports:*)",
+      "Bash(gofmt:*)",
+      "Bash(make:*)",
+      "Bash(goreleaser:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(rm -rf bin/:*)",
+      "Bash(rm -rf dist/:*)",
+      "Bash(rm coverage:*)",
+      "Bash(./bin/gmail-ro:*)",
+      "WebFetch(domain:go.dev)",
+      "WebFetch(domain:pkg.go.dev)",
+      "WebFetch(domain:golang.org)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:goreleaser.com)",
+      "WebFetch(domain:golangci-lint.run)",
+      "WebFetch(domain:developers.google.com)",
+      "WebFetch(domain:*.googleapis.com)",
+      "WebSearch"
+    ],
+    "ask": [
+      "Bash(git rebase:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)"
+    ],
+    "deny": [
+      "Bash(goreleaser release:*)",
+      "Bash(goreleaser publish:*)",
+      "Bash(goreleaser announce:*)",
+      "Bash(goreleaser continue:*)",
+      "Bash(git filter-branch:*)",
+      "Bash(git filter-repo:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf .*:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds standardized Claude Code settings.json for Go development
- Allows common commands: go, make, golangci-lint, goreleaser, git, gh
- Denies CI-only goreleaser operations and dangerous rm commands
- Requires confirmation for git rebase and force push operations

Closes #4

## Test plan
- [ ] Verify settings.json is properly formatted
- [ ] Confirm allowed commands work in Claude Code
- [ ] Verify denied commands are blocked

Generated with [Claude Code](https://claude.ai/code)