### PR TITLE
ci: add Winget manifest validation workflow

### DIFF
--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -1,0 +1,54 @@
+name: Test Winget Manifest
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+
+jobs:
+  validate-winget:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate manifest schema
+        shell: pwsh
+        run: |
+          $testDir = "winget-validate-test"
+          $testVersion = "0.0.1"
+          $testHash = "0000000000000000000000000000000000000000000000000000000000000001"
+
+          New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+
+          # Process version manifest
+          $content = Get-Content "packaging/winget/OpenCliCollective.gmail-ro.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCliCollective.gmail-ro.yaml" $content -Encoding UTF8
+
+          # Process locale manifest
+          $content = Get-Content "packaging/winget/OpenCliCollective.gmail-ro.locale.en-US.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCliCollective.gmail-ro.locale.en-US.yaml" $content -Encoding UTF8
+
+          # Process installer manifest (version + checksum)
+          $content = Get-Content "packaging/winget/OpenCliCollective.gmail-ro.installer.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          $content = $content -replace "0{64}", $testHash
+          Set-Content "$testDir/OpenCliCollective.gmail-ro.installer.yaml" $content -Encoding UTF8
+
+          Write-Host "Generated test manifests:"
+          Get-ChildItem $testDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating winget manifest schema..."
+          winget validate --manifest $testDir/
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest schema validation failed"
+            exit 1
+          }
+          Write-Host "Manifest schema validation passed!"


### PR DESCRIPTION
## Summary

- Add CI workflow to validate Winget manifest schema on PRs and pushes
- Runs on windows-latest with winget CLI pre-installed
- Substitutes test values for placeholders before validation
- Fails CI if manifest schema is invalid

## Implementation Details

The workflow:
1. Triggers on changes to `packaging/winget/**` or the workflow itself
2. Creates temp directory with processed manifests
3. Replaces `0.0.0` with test version `0.0.1`
4. Replaces 64-zero checksum with test hash
5. Runs `winget validate --manifest <dir>`
6. Exits with error if validation fails

## Test plan

- [ ] Workflow triggers on this PR (touches the workflow file)
- [ ] Winget validation passes for current manifests
- [ ] Intentionally breaking a manifest (e.g., invalid schema version) would fail validation

Closes #8