### PR TITLE
ci: add manual Chocolatey publish workflow

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,0 +1,79 @@
+name: Publish to Chocolatey
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0, without v prefix)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found. Please ensure the release exists before publishing."
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Line = $checksums | Select-String "windows_amd64.zip"
+          if (-not $x64Line) {
+            Write-Error "Could not find windows_amd64.zip checksum in checksums.txt"
+            exit 1
+          }
+          $x64Hash = $x64Line.Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/gmail-ro.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksum into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksum into install script"
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Write-Host "Created package:"
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          $nupkg = (Get-ChildItem *.nupkg).Name
+          Write-Host "Pushing $nupkg to Chocolatey..."
+          choco push $nupkg --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}
+          Write-Host "Successfully pushed to Chocolatey!"


### PR DESCRIPTION
## Summary

- Add workflow_dispatch workflow for manually publishing to Chocolatey
- Validates release exists before proceeding
- Extracts checksum from release assets and injects into install script
- Packs and pushes to Chocolatey community repository

## Use Cases

- Retry failed moderation submissions
- Publish older versions
- Re-publish after fixing package issues

## Required Secret

This workflow requires `CHOCOLATEY_API_KEY` to be configured in repository secrets.

## Test plan

- [ ] Review workflow syntax
- [ ] Verify checksum extraction pattern matches checksums.txt format
- [ ] Confirm placeholder replacement matches packaging files
- [ ] Manual test after merging (requires CHOCOLATEY_API_KEY secret)

Closes #9