### PR TITLE
ci: add manual Winget publish workflow

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,113 @@
+name: Publish to Winget
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0, without v prefix)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          Write-Host "Downloaded wingetcreate"
+
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCliCollective/gmail-ro" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will generate and submit new manifests"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found. Please ensure the release exists before publishing."
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Line = $checksums | Select-String "windows_amd64.zip"
+          if (-not $x64Line) {
+            Write-Error "Could not find windows_amd64.zip checksum in checksums.txt"
+            exit 1
+          }
+          $x64Hash = $x64Line.Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $url = "https://github.com/open-cli-collective/gmail-ro/releases/download/v${version}/gmail-ro_v${version}_windows_amd64.zip"
+
+          Write-Host "Updating existing manifest to version $version"
+          Write-Host "URL: $url"
+          ./wingetcreate.exe update OpenCliCollective.gmail-ro --version $version --urls $url --submit --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCliCollective.gmail-ro.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCliCollective.gmail-ro.yaml" $versionManifest -Encoding UTF8
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCliCollective.gmail-ro.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCliCollective.gmail-ro.locale.en-US.yaml" $localeManifest -Encoding UTF8
+
+          # Update installer manifest with version and checksum
+          $installerManifest = Get-Content "packaging/winget/OpenCliCollective.gmail-ro.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          $installerManifest = $installerManifest -replace "0{64}", $env:X64_HASH
+          Set-Content "$manifestDir/OpenCliCollective.gmail-ro.installer.yaml" $installerManifest -Encoding UTF8
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir


### PR DESCRIPTION
## Summary

- Add workflow_dispatch workflow for manually submitting to Winget
- Handles both new package submissions and updates to existing packages
- Detects existing manifest via GitHub API before deciding approach
- For updates: Uses `wingetcreate update` command
- For new: Generates manifests from templates, validates, and submits

## Use Cases

- Submit first version to Winget
- Retry failed submissions
- Publish older versions
- Re-publish after fixing manifest issues

## Required Secret

This workflow requires `WINGET_GITHUB_TOKEN` to be configured in repository secrets.
Must be a GitHub PAT with `public_repo` scope.

## Test plan

- [ ] Review workflow syntax
- [ ] Verify manifest existence check URL is correct
- [ ] Confirm checksum extraction pattern matches checksums.txt format
- [ ] Manual test after merging (requires WINGET_GITHUB_TOKEN secret)

Closes #10