### PR TITLE
fix(chocolatey): use descriptive package title

### DIFF
--- a/packaging/chocolatey/gmail-ro.nuspec
+++ b/packaging/chocolatey/gmail-ro.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>gmail-ro</id>
     <version>0.0.0</version>
-    <title>gmail-ro</title>
+    <title>Gmail Read-Only CLI</title>
     <authors>Caleb Piekstra</authors>
     <owners>open-cli-collective</owners>
     <licenseUrl>https://github.com/open-cli-collective/gmail-ro/blob/main/LICENSE</licenseUrl>


### PR DESCRIPTION
## Summary
- Changed Chocolatey package title from `gmail-ro` to `Gmail Read-Only CLI`
- Addresses review feedback about title matching package ID

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)