### PR TITLE
feat(attachments): add attachment listing, downloading, and zip extraction

### DIFF
--- a/cmd/attachments.go
+++ b/cmd/attachments.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(attachmentsCmd)
+}
+
+var attachmentsCmd = &cobra.Command{
+	Use:   "attachments",
+	Short: "Manage message attachments",
+	Long: `List and download attachments from Gmail messages.
+
+This command group provides read-only access to message attachments.
+Use 'list' to view attachment metadata and 'download' to save files locally.
+
+Examples:
+  gmail-ro attachments list 18abc123def456
+  gmail-ro attachments download 18abc123def456 --all
+  gmail-ro attachments download 18abc123def456 --filename report.pdf`,
+}

--- a/cmd/attachments_download.go
+++ b/cmd/attachments_download.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/piekstra/gmail-ro/internal/gmail"
+	ziputil "github.com/piekstra/gmail-ro/internal/zip"
+	"github.com/spf13/cobra"
+)
+
+var (
+	downloadFilename string
+	downloadDir      string
+	downloadExtract  bool
+	downloadAll      bool
+)
+
+func init() {
+	attachmentsCmd.AddCommand(downloadAttachmentsCmd)
+	downloadAttachmentsCmd.Flags().StringVarP(&downloadFilename, "filename", "f", "",
+		"Download only attachment with this filename")
+	downloadAttachmentsCmd.Flags().StringVarP(&downloadDir, "output", "o", ".",
+		"Directory to save attachments")
+	downloadAttachmentsCmd.Flags().BoolVarP(&downloadExtract, "extract", "e", false,
+		"Extract zip files after download")
+	downloadAttachmentsCmd.Flags().BoolVarP(&downloadAll, "all", "a", false,
+		"Download all attachments (required if no --filename specified)")
+}
+
+var downloadAttachmentsCmd = &cobra.Command{
+	Use:   "download <message-id>",
+	Short: "Download attachments from a message",
+	Long: `Download attachments from a Gmail message to local disk.
+
+By default, requires --filename to specify which attachment to download,
+or --all to download all attachments.
+
+Zip files can be automatically extracted with --extract flag.
+
+Examples:
+  gmail-ro attachments download 18abc123def456 --filename report.pdf
+  gmail-ro attachments download 18abc123def456 --all
+  gmail-ro attachments download 18abc123def456 --all --output ~/Downloads
+  gmail-ro attachments download 18abc123def456 --filename archive.zip --extract`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if downloadFilename == "" && !downloadAll {
+			return fmt.Errorf("must specify --filename or --all")
+		}
+
+		ctx := context.Background()
+		client, err := gmail.NewClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		messageID := args[0]
+		attachments, err := client.GetAttachments(messageID)
+		if err != nil {
+			return err
+		}
+
+		if len(attachments) == 0 {
+			fmt.Println("No attachments found.")
+			return nil
+		}
+
+		// Filter by filename if specified
+		var toDownload []*gmail.Attachment
+		for _, att := range attachments {
+			if downloadFilename == "" || att.Filename == downloadFilename {
+				toDownload = append(toDownload, att)
+			}
+		}
+
+		if len(toDownload) == 0 {
+			return fmt.Errorf("attachment not found: %s", downloadFilename)
+		}
+
+		// Create output directory if needed
+		if err := os.MkdirAll(downloadDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
+
+		// Download each attachment
+		for _, att := range toDownload {
+			data, err := downloadAttachment(client, messageID, att)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error downloading %s: %v\n", att.Filename, err)
+				continue
+			}
+
+			outputPath := filepath.Join(downloadDir, att.Filename)
+			if err := saveAttachment(outputPath, data); err != nil {
+				fmt.Fprintf(os.Stderr, "Error saving %s: %v\n", att.Filename, err)
+				continue
+			}
+
+			fmt.Printf("Downloaded: %s (%s)\n", outputPath, formatSize(int64(len(data))))
+
+			// Extract if zip and --extract flag
+			if downloadExtract && isZipFile(att.Filename, att.MimeType) {
+				extractDir := filepath.Join(downloadDir,
+					strings.TrimSuffix(att.Filename, filepath.Ext(att.Filename)))
+				if err := ziputil.Extract(outputPath, extractDir, ziputil.DefaultOptions()); err != nil {
+					fmt.Fprintf(os.Stderr, "Error extracting %s: %v\n", att.Filename, err)
+				} else {
+					fmt.Printf("Extracted to: %s\n", extractDir)
+				}
+			}
+		}
+
+		return nil
+	},
+}
+
+func downloadAttachment(client *gmail.Client, messageID string, att *gmail.Attachment) ([]byte, error) {
+	if att.AttachmentID != "" {
+		return client.DownloadAttachment(messageID, att.AttachmentID)
+	}
+	return client.DownloadInlineAttachment(messageID, att.PartID)
+}
+
+func saveAttachment(path string, data []byte) error {
+	return os.WriteFile(path, data, 0644)
+}
+
+func isZipFile(filename, mimeType string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".zip" ||
+		mimeType == "application/zip" ||
+		mimeType == "application/x-zip-compressed"
+}

--- a/cmd/attachments_list.go
+++ b/cmd/attachments_list.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/piekstra/gmail-ro/internal/gmail"
+	"github.com/spf13/cobra"
+)
+
+var listAttachmentsJSON bool
+
+func init() {
+	attachmentsCmd.AddCommand(listAttachmentsCmd)
+	listAttachmentsCmd.Flags().BoolVarP(&listAttachmentsJSON, "json", "j", false, "Output as JSON")
+}
+
+var listAttachmentsCmd = &cobra.Command{
+	Use:   "list <message-id>",
+	Short: "List attachments in a message",
+	Long: `List all attachments in a Gmail message with their metadata.
+
+Shows filename, MIME type, size, and whether the attachment is inline.
+
+Examples:
+  gmail-ro attachments list 18abc123def456
+  gmail-ro attachments list 18abc123def456 --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		client, err := gmail.NewClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		attachments, err := client.GetAttachments(args[0])
+		if err != nil {
+			return err
+		}
+
+		if len(attachments) == 0 {
+			fmt.Println("No attachments found.")
+			return nil
+		}
+
+		if listAttachmentsJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(attachments)
+		}
+
+		fmt.Printf("Found %d attachment(s):\n\n", len(attachments))
+		for i, att := range attachments {
+			fmt.Printf("%d. %s\n", i+1, att.Filename)
+			fmt.Printf("   Type: %s\n", att.MimeType)
+			fmt.Printf("   Size: %s\n", formatSize(att.Size))
+			if att.IsInline {
+				fmt.Printf("   Inline: yes\n")
+			}
+			fmt.Println()
+		}
+
+		return nil
+	},
+}
+
+// formatSize converts bytes to human-readable format
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/attachments_test.go
+++ b/cmd/attachments_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsZipFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		mimeType string
+		expected bool
+	}{
+		{"zip extension lowercase", "archive.zip", "", true},
+		{"zip extension uppercase", "ARCHIVE.ZIP", "", true},
+		{"zip extension mixed case", "Archive.Zip", "", true},
+		{"application/zip mime type", "archive", "application/zip", true},
+		{"application/x-zip-compressed mime type", "archive", "application/x-zip-compressed", true},
+		{"pdf file", "document.pdf", "application/pdf", false},
+		{"txt file", "readme.txt", "text/plain", false},
+		{"no extension with wrong mime", "archive", "application/octet-stream", false},
+		{"zip extension with different mime", "archive.zip", "application/octet-stream", true},
+		{"empty filename with zip mime", "", "application/zip", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isZipFile(tt.filename, tt.mimeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    int64
+		expected string
+	}{
+		{"zero bytes", 0, "0 B"},
+		{"small bytes", 500, "500 B"},
+		{"exactly 1KB", 1024, "1.0 KB"},
+		{"1.5 KB", 1536, "1.5 KB"},
+		{"exactly 1MB", 1024 * 1024, "1.0 MB"},
+		{"2.5 MB", 2621440, "2.5 MB"},
+		{"exactly 1GB", 1024 * 1024 * 1024, "1.0 GB"},
+		{"large file", 5368709120, "5.0 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatSize(tt.bytes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAttachmentsCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "attachments", attachmentsCmd.Use)
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := attachmentsCmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 2)
+
+		var names []string
+		for _, cmd := range subcommands {
+			names = append(names, cmd.Name())
+		}
+		assert.Contains(t, names, "list")
+		assert.Contains(t, names, "download")
+	})
+}
+
+func TestListAttachmentsCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "list <message-id>", listAttachmentsCmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := listAttachmentsCmd.Args(listAttachmentsCmd, []string{})
+		assert.Error(t, err)
+
+		err = listAttachmentsCmd.Args(listAttachmentsCmd, []string{"msg123"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("has json flag", func(t *testing.T) {
+		flag := listAttachmentsCmd.Flags().Lookup("json")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "j", flag.Shorthand)
+	})
+}
+
+func TestDownloadAttachmentsCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "download <message-id>", downloadAttachmentsCmd.Use)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		err := downloadAttachmentsCmd.Args(downloadAttachmentsCmd, []string{})
+		assert.Error(t, err)
+
+		err = downloadAttachmentsCmd.Args(downloadAttachmentsCmd, []string{"msg123"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("has required flags", func(t *testing.T) {
+		flags := []struct {
+			name      string
+			shorthand string
+		}{
+			{"filename", "f"},
+			{"output", "o"},
+			{"extract", "e"},
+			{"all", "a"},
+		}
+
+		for _, f := range flags {
+			flag := downloadAttachmentsCmd.Flags().Lookup(f.name)
+			assert.NotNil(t, flag, "flag %s should exist", f.name)
+			assert.Equal(t, f.shorthand, flag.Shorthand, "flag %s should have shorthand %s", f.name, f.shorthand)
+		}
+	})
+}

--- a/internal/gmail/attachments.go
+++ b/internal/gmail/attachments.go
@@ -1,0 +1,79 @@
+package gmail
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+// GetAttachments retrieves attachment metadata for a message
+func (c *Client) GetAttachments(messageID string) ([]*Attachment, error) {
+	msg, err := c.Service.Users.Messages.Get(c.UserID, messageID).Format("full").Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get message: %w", err)
+	}
+
+	return extractAttachments(msg.Payload, ""), nil
+}
+
+// DownloadAttachment downloads a single attachment by message ID and attachment ID
+func (c *Client) DownloadAttachment(messageID string, attachmentID string) ([]byte, error) {
+	att, err := c.Service.Users.Messages.Attachments.Get(c.UserID, messageID, attachmentID).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to download attachment: %w", err)
+	}
+
+	data, err := base64.URLEncoding.DecodeString(att.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode attachment data: %w", err)
+	}
+
+	return data, nil
+}
+
+// DownloadInlineAttachment downloads an attachment that has inline data
+func (c *Client) DownloadInlineAttachment(messageID string, partID string) ([]byte, error) {
+	msg, err := c.Service.Users.Messages.Get(c.UserID, messageID).Format("full").Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get message: %w", err)
+	}
+
+	part := findPart(msg.Payload, partID)
+	if part == nil {
+		return nil, fmt.Errorf("attachment part not found: %s", partID)
+	}
+
+	if part.Body == nil || part.Body.Data == "" {
+		return nil, fmt.Errorf("attachment has no inline data")
+	}
+
+	data, err := base64.URLEncoding.DecodeString(part.Body.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode inline attachment: %w", err)
+	}
+
+	return data, nil
+}
+
+// findPart recursively finds a message part by its path (e.g., "0.1.2")
+func findPart(payload *gmail.MessagePart, partPath string) *gmail.MessagePart {
+	if partPath == "" {
+		return payload
+	}
+
+	parts := strings.Split(partPath, ".")
+	current := payload
+
+	for _, indexStr := range parts {
+		index, err := strconv.Atoi(indexStr)
+		if err != nil || index < 0 || index >= len(current.Parts) {
+			return nil
+		}
+		current = current.Parts[index]
+	}
+
+	return current
+}

--- a/internal/gmail/attachments_test.go
+++ b/internal/gmail/attachments_test.go
@@ -1,0 +1,106 @@
+package gmail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/gmail/v1"
+)
+
+func TestFindPart(t *testing.T) {
+	t.Run("returns payload for empty path", func(t *testing.T) {
+		payload := &gmail.MessagePart{
+			MimeType: "text/plain",
+		}
+		result := findPart(payload, "")
+		assert.Equal(t, payload, result)
+	})
+
+	t.Run("finds part at index 0", func(t *testing.T) {
+		child := &gmail.MessagePart{MimeType: "text/plain", Filename: "file.txt"}
+		payload := &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts:    []*gmail.MessagePart{child},
+		}
+		result := findPart(payload, "0")
+		assert.Equal(t, child, result)
+	})
+
+	t.Run("finds nested part", func(t *testing.T) {
+		deepChild := &gmail.MessagePart{MimeType: "application/pdf", Filename: "nested.pdf"}
+		payload := &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts: []*gmail.MessagePart{
+				{
+					MimeType: "multipart/alternative",
+					Parts: []*gmail.MessagePart{
+						{MimeType: "text/plain"},
+						deepChild,
+					},
+				},
+			},
+		}
+		result := findPart(payload, "0.1")
+		assert.Equal(t, deepChild, result)
+	})
+
+	t.Run("returns nil for invalid index", func(t *testing.T) {
+		payload := &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts:    []*gmail.MessagePart{{MimeType: "text/plain"}},
+		}
+		result := findPart(payload, "5")
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil for negative index", func(t *testing.T) {
+		payload := &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts:    []*gmail.MessagePart{{MimeType: "text/plain"}},
+		}
+		result := findPart(payload, "-1")
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil for non-numeric path", func(t *testing.T) {
+		payload := &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts:    []*gmail.MessagePart{{MimeType: "text/plain"}},
+		}
+		result := findPart(payload, "abc")
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil for out of bounds nested path", func(t *testing.T) {
+		payload := &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts: []*gmail.MessagePart{
+				{
+					MimeType: "multipart/alternative",
+					Parts:    []*gmail.MessagePart{{MimeType: "text/plain"}},
+				},
+			},
+		}
+		result := findPart(payload, "0.5")
+		assert.Nil(t, result)
+	})
+
+	t.Run("handles deeply nested path", func(t *testing.T) {
+		deepest := &gmail.MessagePart{Filename: "deep.txt"}
+		payload := &gmail.MessagePart{
+			Parts: []*gmail.MessagePart{
+				{
+					Parts: []*gmail.MessagePart{
+						{
+							Parts: []*gmail.MessagePart{
+								deepest,
+							},
+						},
+					},
+				},
+			},
+		}
+		result := findPart(payload, "0.0.0")
+		assert.Equal(t, deepest, result)
+	})
+}

--- a/internal/zip/extract.go
+++ b/internal/zip/extract.go
@@ -1,0 +1,161 @@
+package zip
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// MaxFileSize is the maximum size of a single extracted file (100MB)
+	MaxFileSize = 100 * 1024 * 1024
+	// MaxTotalSize is the maximum total extracted size (500MB)
+	MaxTotalSize = 500 * 1024 * 1024
+	// MaxFiles is the maximum number of files to extract
+	MaxFiles = 1000
+	// MaxDepth is the maximum nesting depth for extracted directories
+	MaxDepth = 10
+)
+
+// Options configures zip extraction behavior
+type Options struct {
+	MaxFileSize  int64
+	MaxTotalSize int64
+	MaxFiles     int
+	MaxDepth     int
+}
+
+// DefaultOptions returns safe default extraction options
+func DefaultOptions() Options {
+	return Options{
+		MaxFileSize:  MaxFileSize,
+		MaxTotalSize: MaxTotalSize,
+		MaxFiles:     MaxFiles,
+		MaxDepth:     MaxDepth,
+	}
+}
+
+// Extract safely extracts a zip file to the destination directory
+func Extract(zipPath, destDir string, opts Options) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to open zip: %w", err)
+	}
+	defer r.Close()
+
+	// Validate before extraction
+	if err := validateZip(&r.Reader, opts); err != nil {
+		return err
+	}
+
+	// Create destination directory
+	destDir, err = filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination path: %w", err)
+	}
+	if err := fs.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination: %w", err)
+	}
+
+	var totalSize int64
+	for _, f := range r.File {
+		if err := extractFile(f, destDir, opts, &totalSize); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateZip(r *zip.Reader, opts Options) error {
+	if len(r.File) > opts.MaxFiles {
+		return fmt.Errorf("zip contains too many files: %d (max %d)",
+			len(r.File), opts.MaxFiles)
+	}
+
+	var totalSize uint64
+	for _, f := range r.File {
+		// Check for zip bomb (compression ratio attack)
+		if f.UncompressedSize64 > uint64(opts.MaxFileSize) {
+			return fmt.Errorf("file %s exceeds max size: %d bytes",
+				f.Name, f.UncompressedSize64)
+		}
+		totalSize += f.UncompressedSize64
+	}
+
+	if totalSize > uint64(opts.MaxTotalSize) {
+		return fmt.Errorf("total extracted size exceeds limit: %d bytes (max %d)",
+			totalSize, opts.MaxTotalSize)
+	}
+
+	return nil
+}
+
+func extractFile(f *zip.File, destDir string, opts Options, totalSize *int64) error {
+	// Security: Prevent path traversal attacks
+	name := filepath.Clean(f.Name)
+
+	// Reject absolute paths and paths starting with ..
+	if filepath.IsAbs(name) || strings.HasPrefix(name, ".."+string(os.PathSeparator)) || name == ".." {
+		return fmt.Errorf("invalid file path in zip: %s", f.Name)
+	}
+
+	// Check nesting depth
+	depth := strings.Count(name, string(os.PathSeparator))
+	if depth > opts.MaxDepth {
+		return fmt.Errorf("file path too deep: %s (depth %d, max %d)",
+			name, depth, opts.MaxDepth)
+	}
+
+	destPath := filepath.Join(destDir, name)
+
+	// Security: Ensure the destination is within destDir (handles symlink attacks)
+	cleanDest := filepath.Clean(destPath)
+	if !strings.HasPrefix(cleanDest, destDir+string(os.PathSeparator)) && cleanDest != destDir {
+		return fmt.Errorf("path traversal detected: %s", f.Name)
+	}
+
+	if f.FileInfo().IsDir() {
+		return fs.MkdirAll(destPath, f.Mode())
+	}
+
+	// Create parent directories
+	if err := fs.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+
+	// Extract file with size limit
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	outFile, err := fs.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	// Use LimitedReader to enforce size limits during extraction
+	limitedReader := &io.LimitedReader{R: rc, N: opts.MaxFileSize + 1}
+	written, err := io.Copy(outFile, limitedReader)
+	if err != nil {
+		return err
+	}
+
+	if written > opts.MaxFileSize {
+		_ = fs.Remove(destPath)
+		return fmt.Errorf("file %s exceeds max size during extraction", f.Name)
+	}
+
+	*totalSize += written
+	if *totalSize > opts.MaxTotalSize {
+		return fmt.Errorf("total extracted size exceeds limit")
+	}
+
+	return nil
+}

--- a/internal/zip/extract_test.go
+++ b/internal/zip/extract_test.go
@@ -1,0 +1,438 @@
+package zip
+
+import (
+	"archive/zip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestZip(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("", "test-*.zip")
+	require.NoError(t, err)
+	defer tmpFile.Close()
+
+	w := zip.NewWriter(tmpFile)
+	for name, content := range files {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+
+	return tmpFile.Name()
+}
+
+func TestExtract(t *testing.T) {
+	t.Run("extracts simple zip file", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"file1.txt": []byte("content 1"),
+			"file2.txt": []byte("content 2"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		err := Extract(zipPath, destDir, DefaultOptions())
+		require.NoError(t, err)
+
+		content1, err := os.ReadFile(filepath.Join(destDir, "file1.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "content 1", string(content1))
+
+		content2, err := os.ReadFile(filepath.Join(destDir, "file2.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "content 2", string(content2))
+	})
+
+	t.Run("extracts nested directories", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"dir1/file1.txt":      []byte("nested 1"),
+			"dir1/dir2/file2.txt": []byte("nested 2"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		err := Extract(zipPath, destDir, DefaultOptions())
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(destDir, "dir1", "dir2", "file2.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "nested 2", string(content))
+	})
+
+	t.Run("creates destination directory if not exists", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"test.txt": []byte("test"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := filepath.Join(t.TempDir(), "new", "nested", "dir")
+		err := Extract(zipPath, destDir, DefaultOptions())
+		require.NoError(t, err)
+
+		_, err = os.Stat(filepath.Join(destDir, "test.txt"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects invalid zip file", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "invalid-*.zip")
+		require.NoError(t, err)
+		tmpFile.WriteString("not a zip file")
+		tmpFile.Close()
+		defer os.Remove(tmpFile.Name())
+
+		destDir := t.TempDir()
+		err = Extract(tmpFile.Name(), destDir, DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to open zip")
+	})
+}
+
+func TestExtractSecurityPathTraversal(t *testing.T) {
+	t.Run("rejects path with leading ..", func(t *testing.T) {
+		// Create a malicious zip with path traversal
+		tmpFile, err := os.CreateTemp("", "malicious-*.zip")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		w := zip.NewWriter(tmpFile)
+		// Manually create a file with path traversal
+		header := &zip.FileHeader{
+			Name:   "../../../etc/passwd",
+			Method: zip.Store,
+		}
+		f, err := w.CreateHeader(header)
+		require.NoError(t, err)
+		f.Write([]byte("malicious"))
+		w.Close()
+		tmpFile.Close()
+
+		destDir := t.TempDir()
+		err = Extract(tmpFile.Name(), destDir, DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid file path")
+	})
+
+	t.Run("rejects absolute paths", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "malicious-*.zip")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		w := zip.NewWriter(tmpFile)
+		header := &zip.FileHeader{
+			Name:   "/etc/passwd",
+			Method: zip.Store,
+		}
+		f, err := w.CreateHeader(header)
+		require.NoError(t, err)
+		f.Write([]byte("malicious"))
+		w.Close()
+		tmpFile.Close()
+
+		destDir := t.TempDir()
+		err = Extract(tmpFile.Name(), destDir, DefaultOptions())
+		assert.Error(t, err)
+	})
+}
+
+func TestExtractSecurityLimits(t *testing.T) {
+	t.Run("rejects zip with too many files", func(t *testing.T) {
+		files := make(map[string][]byte)
+		for i := 0; i < 10; i++ {
+			files[filepath.Join("file", string(rune('a'+i))+".txt")] = []byte("x")
+		}
+		zipPath := createTestZip(t, files)
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		opts := Options{
+			MaxFileSize:  MaxFileSize,
+			MaxTotalSize: MaxTotalSize,
+			MaxFiles:     5, // Less than files in zip
+			MaxDepth:     MaxDepth,
+		}
+		err := Extract(zipPath, destDir, opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too many files")
+	})
+
+	t.Run("rejects file exceeding max size", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"large.txt": make([]byte, 1000),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		opts := Options{
+			MaxFileSize:  100, // Less than file size
+			MaxTotalSize: MaxTotalSize,
+			MaxFiles:     MaxFiles,
+			MaxDepth:     MaxDepth,
+		}
+		err := Extract(zipPath, destDir, opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds max size")
+	})
+
+	t.Run("rejects total size exceeding limit", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"file1.txt": make([]byte, 600),
+			"file2.txt": make([]byte, 600),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		opts := Options{
+			MaxFileSize:  MaxFileSize,
+			MaxTotalSize: 1000, // Less than total
+			MaxFiles:     MaxFiles,
+			MaxDepth:     MaxDepth,
+		}
+		err := Extract(zipPath, destDir, opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds limit")
+	})
+
+	t.Run("rejects path too deep", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"a/b/c/d/e/f/deep.txt": []byte("deep"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		opts := Options{
+			MaxFileSize:  MaxFileSize,
+			MaxTotalSize: MaxTotalSize,
+			MaxFiles:     MaxFiles,
+			MaxDepth:     3, // Less than actual depth
+		}
+		err := Extract(zipPath, destDir, opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too deep")
+	})
+}
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	assert.Equal(t, int64(MaxFileSize), opts.MaxFileSize)
+	assert.Equal(t, int64(MaxTotalSize), opts.MaxTotalSize)
+	assert.Equal(t, MaxFiles, opts.MaxFiles)
+	assert.Equal(t, MaxDepth, opts.MaxDepth)
+}
+
+func TestValidateZip(t *testing.T) {
+	t.Run("accepts valid zip within limits", func(t *testing.T) {
+		zipPath := createTestZip(t, map[string][]byte{
+			"file1.txt": []byte("content"),
+		})
+		defer os.Remove(zipPath)
+
+		r, err := zip.OpenReader(zipPath)
+		require.NoError(t, err)
+		defer r.Close()
+
+		err = validateZip(&r.Reader, DefaultOptions())
+		assert.NoError(t, err)
+	})
+}
+
+// mockFS implements FileSystem for testing error paths
+type mockFS struct {
+	mkdirAllErr error
+	openFileErr error
+	mkdirCalls  int
+	failAfterN  int // fail MkdirAll after N calls (0 = fail immediately)
+}
+
+func (m *mockFS) MkdirAll(path string, perm os.FileMode) error {
+	m.mkdirCalls++
+	if m.failAfterN > 0 && m.mkdirCalls <= m.failAfterN {
+		return nil
+	}
+	return m.mkdirAllErr
+}
+
+func (m *mockFS) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	if m.openFileErr != nil {
+		return nil, m.openFileErr
+	}
+	return os.OpenFile(name, flag, perm)
+}
+
+func (m *mockFS) Remove(name string) error {
+	return os.Remove(name)
+}
+
+// errorWriter is a writer that fails after writing some bytes
+type errorWriter struct {
+	written int
+	failAt  int
+	err     error
+}
+
+func (w *errorWriter) Write(p []byte) (int, error) {
+	if w.written >= w.failAt {
+		return 0, w.err
+	}
+	w.written += len(p)
+	return len(p), nil
+}
+
+func (w *errorWriter) Close() error {
+	return nil
+}
+
+// mockFSWithErrorWriter returns an error writer instead of a real file
+type mockFSWithErrorWriter struct {
+	writer *errorWriter
+}
+
+func (m *mockFSWithErrorWriter) MkdirAll(path string, perm os.FileMode) error {
+	return nil
+}
+
+func (m *mockFSWithErrorWriter) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	return m.writer, nil
+}
+
+func (m *mockFSWithErrorWriter) Remove(name string) error {
+	return nil
+}
+
+func TestExtractFileSystemErrors(t *testing.T) {
+	// Save original fs and restore after tests
+	originalFS := fs
+	defer func() { fs = originalFS }()
+
+	t.Run("returns error when MkdirAll fails for destination", func(t *testing.T) {
+		fs = &mockFS{
+			mkdirAllErr: errors.New("permission denied"),
+		}
+
+		zipPath := createTestZip(t, map[string][]byte{
+			"test.txt": []byte("content"),
+		})
+		defer os.Remove(zipPath)
+
+		err := Extract(zipPath, "/tmp/test-dest", DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create destination")
+	})
+
+	t.Run("returns error when MkdirAll fails for parent directory", func(t *testing.T) {
+		fs = &mockFS{
+			mkdirAllErr: errors.New("disk full"),
+			failAfterN:  1, // succeed for dest dir, fail for parent dir
+		}
+
+		zipPath := createTestZip(t, map[string][]byte{
+			"subdir/test.txt": []byte("content"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		err := Extract(zipPath, destDir, DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "disk full")
+	})
+
+	t.Run("returns error when OpenFile fails", func(t *testing.T) {
+		fs = &mockFS{
+			openFileErr: errors.New("too many open files"),
+		}
+
+		zipPath := createTestZip(t, map[string][]byte{
+			"test.txt": []byte("content"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		err := Extract(zipPath, destDir, DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too many open files")
+	})
+
+	t.Run("returns error when io.Copy fails", func(t *testing.T) {
+		fs = &mockFSWithErrorWriter{
+			writer: &errorWriter{
+				failAt: 0,
+				err:    errors.New("write error"),
+			},
+		}
+
+		zipPath := createTestZip(t, map[string][]byte{
+			"test.txt": []byte("content"),
+		})
+		defer os.Remove(zipPath)
+
+		destDir := t.TempDir()
+		err := Extract(zipPath, destDir, DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "write error")
+	})
+}
+
+func TestExtractDirectoryEntry(t *testing.T) {
+	// Save original fs and restore after test
+	originalFS := fs
+	defer func() { fs = originalFS }()
+
+	t.Run("extracts directory entries", func(t *testing.T) {
+		// Create zip with explicit directory entry
+		tmpFile, err := os.CreateTemp("", "dir-test-*.zip")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		w := zip.NewWriter(tmpFile)
+		// Create a directory entry with proper permissions
+		header := &zip.FileHeader{
+			Name:   "mydir/",
+			Method: zip.Store,
+		}
+		header.SetMode(os.ModeDir | 0755)
+		_, err = w.CreateHeader(header)
+		require.NoError(t, err)
+		w.Close()
+		tmpFile.Close()
+
+		destDir := t.TempDir()
+		err = Extract(tmpFile.Name(), destDir, DefaultOptions())
+		require.NoError(t, err)
+
+		// Verify directory was created
+		info, err := os.Stat(filepath.Join(destDir, "mydir"))
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("returns error when MkdirAll fails for directory entry", func(t *testing.T) {
+		fs = &mockFS{
+			mkdirAllErr: errors.New("cannot create directory"),
+			failAfterN:  1, // succeed for dest dir, fail for directory entry
+		}
+
+		// Create zip with explicit directory entry
+		tmpFile, err := os.CreateTemp("", "dir-test-*.zip")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		w := zip.NewWriter(tmpFile)
+		_, err = w.Create("mydir/")
+		require.NoError(t, err)
+		w.Close()
+		tmpFile.Close()
+
+		destDir := t.TempDir()
+		err = Extract(tmpFile.Name(), destDir, DefaultOptions())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot create directory")
+	})
+}

--- a/internal/zip/fs.go
+++ b/internal/zip/fs.go
@@ -1,0 +1,31 @@
+package zip
+
+import (
+	"io"
+	"os"
+)
+
+// FileSystem abstracts filesystem operations for testing
+type FileSystem interface {
+	MkdirAll(path string, perm os.FileMode) error
+	OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error)
+	Remove(name string) error
+}
+
+// osFS is the real filesystem implementation
+type osFS struct{}
+
+func (osFS) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (osFS) OpenFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (osFS) Remove(name string) error {
+	return os.Remove(name)
+}
+
+// fs is the package-level filesystem, swappable in tests
+var fs FileSystem = osFS{}


### PR DESCRIPTION
## Summary

- Add `attachments list` command to view attachment metadata (filename, MIME type, size)
- Add `attachments download` command with `--all` or `--filename` options
- Add optional `--extract` flag for automatic zip file extraction with security safeguards
- Detect attachments via filename and Content-Disposition header
- Support both inline attachments and large attachments requiring separate API calls

## New Commands

```bash
# List attachments
gmail-ro attachments list <message-id>
gmail-ro attachments list <message-id> --json

# Download attachments
gmail-ro attachments download <message-id> --all
gmail-ro attachments download <message-id> --filename report.pdf
gmail-ro attachments download <message-id> --all --output ~/Downloads

# Download and extract zip files
gmail-ro attachments download <message-id> --filename data.zip --extract
```

## Security

Zip extraction includes safeguards against:
- **Zip bombs**: Pre-validation of sizes, 100MB per-file and 500MB total limits
- **Path traversal**: Clean paths, reject `..` prefixes, verify destination within target directory
- **Resource exhaustion**: Max 1000 files, 10 levels of nesting depth

## Test Plan

- [x] `make verify` passes (lint, format, tests)
- [x] `gmail-ro attachments --help` shows correct usage
- [x] Unit tests for attachment detection logic
- [x] Unit tests for zip extraction including security edge cases

Closes #26