### PR TITLE
refactor: extract shared message formatting helper

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/piekstra/gmail-ro/internal/gmail"
+)
+
+// MessagePrintOptions controls which fields to include in message output
+type MessagePrintOptions struct {
+	IncludeThreadID bool
+	IncludeTo       bool
+	IncludeSnippet  bool
+	IncludeBody     bool
+}
+
+// printMessageHeader prints the common header fields of a message
+func printMessageHeader(msg *gmail.Message, opts MessagePrintOptions) {
+	fmt.Printf("ID: %s\n", msg.ID)
+	if opts.IncludeThreadID {
+		fmt.Printf("ThreadID: %s\n", msg.ThreadID)
+	}
+	fmt.Printf("From: %s\n", msg.From)
+	if opts.IncludeTo {
+		fmt.Printf("To: %s\n", msg.To)
+	}
+	fmt.Printf("Subject: %s\n", msg.Subject)
+	fmt.Printf("Date: %s\n", msg.Date)
+	if len(msg.Labels) > 0 {
+		fmt.Printf("Labels: %s\n", strings.Join(msg.Labels, ", "))
+	}
+	if len(msg.Categories) > 0 {
+		fmt.Printf("Categories: %s\n", strings.Join(msg.Categories, ", "))
+	}
+	if opts.IncludeSnippet {
+		fmt.Printf("Snippet: %s\n", msg.Snippet)
+	}
+	if opts.IncludeBody {
+		fmt.Print("\n--- Body ---\n\n")
+		fmt.Println(msg.Body)
+	}
+}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessagePrintOptions(t *testing.T) {
+	t.Run("default options are all false", func(t *testing.T) {
+		opts := MessagePrintOptions{}
+		assert.False(t, opts.IncludeThreadID)
+		assert.False(t, opts.IncludeTo)
+		assert.False(t, opts.IncludeSnippet)
+		assert.False(t, opts.IncludeBody)
+	})
+
+	t.Run("options can be set individually", func(t *testing.T) {
+		opts := MessagePrintOptions{
+			IncludeThreadID: true,
+			IncludeBody:     true,
+		}
+		assert.True(t, opts.IncludeThreadID)
+		assert.False(t, opts.IncludeTo)
+		assert.False(t, opts.IncludeSnippet)
+		assert.True(t, opts.IncludeBody)
+	})
+}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -47,19 +45,10 @@ Examples:
 			return enc.Encode(msg)
 		}
 
-		fmt.Printf("ID: %s\n", msg.ID)
-		fmt.Printf("From: %s\n", msg.From)
-		fmt.Printf("To: %s\n", msg.To)
-		fmt.Printf("Subject: %s\n", msg.Subject)
-		fmt.Printf("Date: %s\n", msg.Date)
-		if len(msg.Labels) > 0 {
-			fmt.Printf("Labels: %s\n", strings.Join(msg.Labels, ", "))
-		}
-		if len(msg.Categories) > 0 {
-			fmt.Printf("Categories: %s\n", strings.Join(msg.Categories, ", "))
-		}
-		fmt.Print("\n--- Body ---\n\n")
-		fmt.Println(msg.Body)
+		printMessageHeader(msg, MessagePrintOptions{
+			IncludeTo:   true,
+			IncludeBody: true,
+		})
 
 		return nil
 	},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -59,18 +58,10 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 		}
 
 		for _, msg := range messages {
-			fmt.Printf("ID: %s\n", msg.ID)
-			fmt.Printf("ThreadID: %s\n", msg.ThreadID)
-			fmt.Printf("From: %s\n", msg.From)
-			fmt.Printf("Subject: %s\n", msg.Subject)
-			fmt.Printf("Date: %s\n", msg.Date)
-			if len(msg.Labels) > 0 {
-				fmt.Printf("Labels: %s\n", strings.Join(msg.Labels, ", "))
-			}
-			if len(msg.Categories) > 0 {
-				fmt.Printf("Categories: %s\n", strings.Join(msg.Categories, ", "))
-			}
-			fmt.Printf("Snippet: %s\n", msg.Snippet)
+			printMessageHeader(msg, MessagePrintOptions{
+				IncludeThreadID: true,
+				IncludeSnippet:  true,
+			})
 			fmt.Println("---")
 		}
 

--- a/cmd/thread.go
+++ b/cmd/thread.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -58,19 +57,10 @@ Examples:
 		fmt.Printf("Thread contains %d message(s)\n\n", len(messages))
 		for i, msg := range messages {
 			fmt.Printf("=== Message %d of %d ===\n", i+1, len(messages))
-			fmt.Printf("ID: %s\n", msg.ID)
-			fmt.Printf("From: %s\n", msg.From)
-			fmt.Printf("To: %s\n", msg.To)
-			fmt.Printf("Subject: %s\n", msg.Subject)
-			fmt.Printf("Date: %s\n", msg.Date)
-			if len(msg.Labels) > 0 {
-				fmt.Printf("Labels: %s\n", strings.Join(msg.Labels, ", "))
-			}
-			if len(msg.Categories) > 0 {
-				fmt.Printf("Categories: %s\n", strings.Join(msg.Categories, ", "))
-			}
-			fmt.Print("\n--- Body ---\n\n")
-			fmt.Println(msg.Body)
+			printMessageHeader(msg, MessagePrintOptions{
+				IncludeTo:   true,
+				IncludeBody: true,
+			})
 			fmt.Println()
 		}
 


### PR DESCRIPTION
## Summary

Extract duplicated message formatting logic into a shared helper function.

## Changes

- Create `cmd/output.go` with `printMessageHeader()` function and `MessagePrintOptions` struct
- Update `search`, `read`, and `thread` commands to use the shared helper
- Remove duplicate `strings` imports

## Before
Each command had its own copy of 10-15 lines of formatting code. Adding a new field required changes in 3 places.

## After
One shared function with options to control which fields to include:
```go
printMessageHeader(msg, MessagePrintOptions{
    IncludeThreadID: true,
    IncludeSnippet:  true,
})
```

## Test plan
- [x] `make verify` passes
- [x] Output unchanged for all commands

Closes #37