### PR TITLE
refactor: extract shared JSON output helper

### DIFF
--- a/cmd/attachments_list.go
+++ b/cmd/attachments_list.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -46,9 +44,7 @@ Examples:
 		}
 
 		if listAttachmentsJSON {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(attachments)
+			return printJSON(attachments)
 		}
 
 		fmt.Printf("Found %d attachment(s):\n\n", len(attachments))

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -79,9 +77,7 @@ Examples:
 		})
 
 		if labelsJSONOutput {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(labels)
+			return printJSON(labels)
 		}
 
 		// Text output

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,11 +1,20 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 )
+
+// printJSON encodes data as indented JSON to stdout
+func printJSON(data any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(data)
+}
 
 // MessagePrintOptions controls which fields to include in message output
 type MessagePrintOptions struct {

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
-	"os"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -40,9 +38,7 @@ Examples:
 		}
 
 		if readJSONOutput {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(msg)
+			return printJSON(msg)
 		}
 
 		printMessageHeader(msg, MessagePrintOptions{

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -52,9 +50,7 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 		}
 
 		if searchJSONOutput {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(messages)
+			return printJSON(messages)
 		}
 
 		for _, msg := range messages {

--- a/cmd/thread.go
+++ b/cmd/thread.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
@@ -49,9 +47,7 @@ Examples:
 		}
 
 		if threadJSONOutput {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(messages)
+			return printJSON(messages)
 		}
 
 		fmt.Printf("Thread contains %d message(s)\n\n", len(messages))


### PR DESCRIPTION
## Summary

Extract duplicated JSON encoding logic into a shared `printJSON()` helper.

## Changes

- Add `printJSON(data any) error` to `cmd/output.go`
- Update 5 commands to use the shared helper
- Remove duplicate `encoding/json` and `os` imports

## Before
```go
enc := json.NewEncoder(os.Stdout)
enc.SetIndent("", "  ")
return enc.Encode(data)
```

## After
```go
return printJSON(data)
```

## Test plan
- [x] `make verify` passes
- [x] JSON output unchanged

Closes #38