### PR TITLE
refactor: reduce client initialization boilerplate

### DIFF
--- a/cmd/attachments_download.go
+++ b/cmd/attachments_download.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,8 +51,7 @@ Examples:
 			return fmt.Errorf("must specify --filename or --all")
 		}
 
-		ctx := context.Background()
-		client, err := gmail.NewClient(ctx)
+		client, err := newGmailClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/attachments_list.go
+++ b/cmd/attachments_list.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
 )
 
@@ -27,8 +25,7 @@ Examples:
   gmail-ro attachments list 18abc123def456 --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		client, err := gmail.NewClient(ctx)
+		client, err := newGmailClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
 	gmailapi "google.golang.org/api/gmail/v1"
 )
@@ -39,8 +37,7 @@ Examples:
   gmail-ro labels --json`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		client, err := gmail.NewClient(ctx)
+		client, err := newGmailClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,11 @@ import (
 
 	"github.com/piekstra/gmail-ro/internal/gmail"
 )
+
+// newGmailClient creates and returns a new Gmail client
+func newGmailClient() (*gmail.Client, error) {
+	return gmail.NewClient(context.Background())
+}
 
 // printJSON encodes data as indented JSON to stdout
 func printJSON(data any) error {

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
 )
 
@@ -26,8 +23,7 @@ Examples:
   gmail-ro read 18abc123def456 --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		client, err := gmail.NewClient(ctx)
+		client, err := newGmailClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
 )
 
@@ -33,8 +31,7 @@ Examples:
 For more query operators, see: https://support.google.com/mail/answer/7190`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		client, err := gmail.NewClient(ctx)
+		client, err := newGmailClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/thread.go
+++ b/cmd/thread.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
 	"github.com/spf13/cobra"
 )
 
@@ -30,8 +28,7 @@ Examples:
   gmail-ro thread 18abc123def456 --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		client, err := gmail.NewClient(ctx)
+		client, err := newGmailClient()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Extract duplicated client initialization into a shared `newGmailClient()` helper.

## Changes

- Add `newGmailClient()` to `cmd/output.go`
- Update 6 commands to use the shared helper
- Remove redundant `context` and `internal/gmail` imports from commands

## Before
```go
ctx := context.Background()
client, err := gmail.NewClient(ctx)
if err != nil {
    return err
}
```

## After
```go
client, err := newGmailClient()
if err != nil {
    return err
}
```

## Test plan
- [x] `make verify` passes
- [x] All commands still work correctly

Closes #39