### PR TITLE
fix: add feedback when messages fail to fetch during search

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -36,7 +36,7 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 			return err
 		}
 
-		messages, err := client.SearchMessages(args[0], searchMaxResults)
+		messages, skipped, err := client.SearchMessages(args[0], searchMaxResults)
 		if err != nil {
 			return err
 		}
@@ -56,6 +56,10 @@ For more query operators, see: https://support.google.com/mail/answer/7190`,
 				IncludeSnippet:  true,
 			})
 			fmt.Println("---")
+		}
+
+		if skipped > 0 {
+			fmt.Printf("Note: %d message(s) could not be retrieved.\n", skipped)
 		}
 
 		return nil


### PR DESCRIPTION
## Summary

Add user feedback when individual messages fail to fetch during search, instead of silently skipping them.

## Changes

- Update `SearchMessages()` signature to return `([]*Message, int, error)` where `int` is the count of skipped messages
- Display a note to users when any messages failed to fetch

## Output
```
ID: abc123
...
---
Note: 2 message(s) could not be retrieved.
```

## Test plan
- [x] `make verify` passes
- [x] Skipped count only shown when > 0

Closes #40