### PR TITLE
fix: add nil check for msg.Payload before accessing Headers

### DIFF
--- a/internal/gmail/messages.go
+++ b/internal/gmail/messages.go
@@ -122,6 +122,14 @@ func parseMessage(msg *gmail.Message, includeBody bool, resolver LabelResolver) 
 		Snippet:  msg.Snippet,
 	}
 
+	// Extract labels and categories (doesn't need Payload)
+	m.Labels, m.Categories = extractLabelsAndCategories(msg.LabelIds, resolver)
+
+	// Early return if Payload is nil
+	if msg.Payload == nil {
+		return m
+	}
+
 	// Extract headers
 	for _, header := range msg.Payload.Headers {
 		switch strings.ToLower(header.Name) {
@@ -136,13 +144,10 @@ func parseMessage(msg *gmail.Message, includeBody bool, resolver LabelResolver) 
 		}
 	}
 
-	if includeBody && msg.Payload != nil {
+	if includeBody {
 		m.Body = extractBody(msg.Payload)
 		m.Attachments = extractAttachments(msg.Payload, "")
 	}
-
-	// Extract labels and categories
-	m.Labels, m.Categories = extractLabelsAndCategories(msg.LabelIds, resolver)
 
 	return m
 }

--- a/internal/gmail/messages_test.go
+++ b/internal/gmail/messages_test.go
@@ -50,6 +50,25 @@ func TestParseMessage(t *testing.T) {
 		assert.Equal(t, "thread789", result.ThreadID)
 	})
 
+	t.Run("handles nil payload", func(t *testing.T) {
+		msg := &gmail.Message{
+			Id:       "msg123",
+			ThreadId: "thread456",
+			Snippet:  "Preview text",
+			Payload:  nil,
+		}
+
+		result := parseMessage(msg, true, nil)
+
+		// Should not panic, basic fields populated
+		assert.Equal(t, "msg123", result.ID)
+		assert.Equal(t, "thread456", result.ThreadID)
+		assert.Equal(t, "Preview text", result.Snippet)
+		// Headers won't be extracted
+		assert.Empty(t, result.Subject)
+		assert.Empty(t, result.Body)
+	})
+
 	t.Run("handles case-insensitive headers", func(t *testing.T) {
 		msg := &gmail.Message{
 			Id: "msg123",


### PR DESCRIPTION
## Summary

Add defensive nil check for `msg.Payload` before iterating over Headers to prevent potential panic.

## Problem

The previous code accessed `msg.Payload.Headers` on line 126 but the nil check for `msg.Payload` was on line 139 - after the header iteration. If Gmail API ever returned a message with nil Payload, this would panic.

## Changes

- Move nil check before header iteration with early return
- Move label extraction before payload check (doesn't need Payload)
- Add test case for nil payload scenario

## Test plan
- [x] `make verify` passes
- [x] New test for nil payload case

Closes #43