### PR TITLE
refactor: use RunE instead of Run in versionCmd for consistency

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,8 @@ func init() {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Printf("gmail-ro %s\n", Version)
+		return nil
 	},
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -49,7 +49,8 @@ func TestVersionCommand(t *testing.T) {
 		Version = "test-version"
 		defer func() { Version = oldVersion }()
 
-		versionCmd.Run(versionCmd, []string{})
+		err := versionCmd.RunE(versionCmd, []string{})
+		assert.NoError(t, err)
 
 		// Note: output goes to stdout, not the buffer set on rootCmd
 		// This test verifies the command doesn't panic


### PR DESCRIPTION
## Summary

Change `versionCmd` from `Run` to `RunE` for consistency with all other commands.

## Changes

- `cmd/root.go`: Change `Run` to `RunE`, return `nil`
- `cmd/root_test.go`: Update test to call `RunE`

## Test plan
- [x] `make verify` passes
- [x] `gmail-ro version` still works

Closes #44