### PR TITLE
chore: standardize 'no results' message format

### DIFF
--- a/cmd/attachments_download.go
+++ b/cmd/attachments_download.go
@@ -63,7 +63,7 @@ Examples:
 		}
 
 		if len(attachments) == 0 {
-			fmt.Println("No attachments found.")
+			fmt.Println("No attachments found for message.")
 			return nil
 		}
 

--- a/cmd/attachments_list.go
+++ b/cmd/attachments_list.go
@@ -36,7 +36,7 @@ Examples:
 		}
 
 		if len(attachments) == 0 {
-			fmt.Println("No attachments found.")
+			fmt.Println("No attachments found for message.")
 			return nil
 		}
 

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -151,7 +151,7 @@ ATTACHMENT_MSG_ID=$(gmail-ro search "has:attachment" --max 1 --json | jq -r '.[0
 |-----------|---------|-----------------|
 | List attachments | `gmail-ro attachments list "$ATTACHMENT_MSG_ID"` | Shows filename, type, size for each attachment |
 | List JSON | `gmail-ro attachments list "$ATTACHMENT_MSG_ID" --json` | Valid JSON array with attachment metadata |
-| No attachments | `MSG_ID=$(gmail-ro search "is:inbox -has:attachment" --max 1 --json \| jq -r '.[0].id'); gmail-ro attachments list "$MSG_ID"` | "No attachments found." |
+| No attachments | `MSG_ID=$(gmail-ro search "is:inbox -has:attachment" --max 1 --json \| jq -r '.[0].id'); gmail-ro attachments list "$MSG_ID"` | "No attachments found for message." |
 
 ### JSON Validation
 


### PR DESCRIPTION
## Summary

Standardize "no results" messages to follow a consistent format.

## Format

- General: `"No <resource> found."`
- With context: `"No <resource> found for <context>."`

## Changes

- Attachment commands: `"No attachments found."` → `"No attachments found for message."`
- Update integration-tests.md to match

## Final messages

| Command | Message |
|---------|---------|
| search | "No messages found." |
| thread | "No messages found in thread." |
| labels | "No labels found." |
| attachments list/download | "No attachments found for message." |

Closes #45