### PR TITLE
feat(auth): store OAuth tokens in system keychain

### DIFF
--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -1,0 +1,191 @@
+// Package keychain provides secure storage for OAuth tokens using platform-native
+// secure storage mechanisms (macOS Keychain, Linux secret-tool) with file fallback.
+package keychain
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	serviceName = "gmail-ro"
+	tokenKey    = "oauth_token"
+	tokenFile   = "token.json"
+)
+
+// StorageBackend represents where tokens are stored
+type StorageBackend string
+
+const (
+	BackendKeychain   StorageBackend = "Keychain"    // macOS Keychain
+	BackendSecretTool StorageBackend = "secret-tool" // Linux libsecret
+	BackendFile       StorageBackend = "config file" // File fallback
+)
+
+var (
+	// ErrTokenNotFound indicates no token exists in storage
+	ErrTokenNotFound = errors.New("no token found in secure storage")
+)
+
+// configDir returns the configuration directory path
+func configDir() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, serviceName), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", serviceName), nil
+}
+
+// tokenFilePath returns the full path to the token file
+func tokenFilePath() (string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, tokenFile), nil
+}
+
+// GetToken retrieves the OAuth token from secure storage
+func GetToken() (*oauth2.Token, error) {
+	return getToken()
+}
+
+// SetToken stores the OAuth token in secure storage
+func SetToken(token *oauth2.Token) error {
+	return setToken(token)
+}
+
+// DeleteToken removes the OAuth token from secure storage
+func DeleteToken() error {
+	return deleteToken()
+}
+
+// HasStoredToken returns true if a token exists in secure storage
+func HasStoredToken() bool {
+	_, err := GetToken()
+	return err == nil
+}
+
+// GetStorageBackend returns the current storage backend being used
+func GetStorageBackend() StorageBackend {
+	return getStorageBackend()
+}
+
+// IsSecureStorage returns true if using secure storage (keychain/secret-tool)
+func IsSecureStorage() bool {
+	backend := GetStorageBackend()
+	return backend == BackendKeychain || backend == BackendSecretTool
+}
+
+// MigrateFromFile migrates token.json to secure storage if it exists
+func MigrateFromFile(tokenFilePath string) error {
+	// Check if token file exists
+	if _, err := os.Stat(tokenFilePath); os.IsNotExist(err) {
+		return nil // Nothing to migrate
+	}
+
+	// Check if already migrated (token in secure storage)
+	if IsSecureStorage() && HasStoredToken() {
+		return nil // Already migrated
+	}
+
+	// Read token from file
+	f, err := os.Open(tokenFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open token file: %w", err)
+	}
+	defer f.Close()
+
+	var token oauth2.Token
+	if err := json.NewDecoder(f).Decode(&token); err != nil {
+		return fmt.Errorf("failed to parse token file: %w", err)
+	}
+
+	// Store in secure storage
+	if err := SetToken(&token); err != nil {
+		return fmt.Errorf("failed to store token in secure storage: %w", err)
+	}
+
+	// Rename old file to backup
+	backupPath := tokenFilePath + ".backup"
+	if err := os.Rename(tokenFilePath, backupPath); err != nil {
+		// Non-fatal - token is now in secure storage
+		fmt.Fprintf(os.Stderr, "Warning: could not backup old token file: %v\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "Migrated token to secure storage. Backup: %s\n", backupPath)
+	}
+
+	return nil
+}
+
+// File-based storage implementation (fallback)
+
+func getFromConfigFile() (*oauth2.Token, error) {
+	path, err := tokenFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrTokenNotFound
+		}
+		return nil, fmt.Errorf("failed to open token file: %w", err)
+	}
+	defer f.Close()
+
+	var token oauth2.Token
+	if err := json.NewDecoder(f).Decode(&token); err != nil {
+		return nil, fmt.Errorf("failed to parse token file: %w", err)
+	}
+
+	return &token, nil
+}
+
+func setInConfigFile(token *oauth2.Token) error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// Write token with restricted permissions
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to create token file: %w", err)
+	}
+	defer f.Close()
+
+	if err := json.NewEncoder(f).Encode(token); err != nil {
+		return fmt.Errorf("failed to write token: %w", err)
+	}
+
+	return nil
+}
+
+func deleteFromConfigFile() error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete token file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -1,0 +1,122 @@
+//go:build darwin
+
+package keychain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// getToken retrieves the OAuth token from macOS Keychain
+func getToken() (*oauth2.Token, error) {
+	token, err := getFromKeychain()
+	if err == nil {
+		return token, nil
+	}
+
+	// Fall back to config file
+	return getFromConfigFile()
+}
+
+// setToken stores the OAuth token in macOS Keychain
+func setToken(token *oauth2.Token) error {
+	err := setInKeychain(token)
+	if err == nil {
+		return nil
+	}
+
+	// Fall back to config file
+	fmt.Printf("Warning: keychain storage failed, using config file: %v\n", err)
+	return setInConfigFile(token)
+}
+
+// deleteToken removes the OAuth token from storage
+func deleteToken() error {
+	// Try to delete from both keychain and file
+	keychainErr := deleteFromKeychain()
+	fileErr := deleteFromConfigFile()
+
+	// Return keychain error if both fail, otherwise nil
+	if keychainErr != nil && fileErr != nil {
+		return keychainErr
+	}
+	return nil
+}
+
+// getStorageBackend returns the current storage backend
+func getStorageBackend() StorageBackend {
+	// Check if token exists in keychain
+	_, err := getFromKeychain()
+	if err == nil {
+		return BackendKeychain
+	}
+
+	// Check if token exists in file
+	_, err = getFromConfigFile()
+	if err == nil {
+		return BackendFile
+	}
+
+	// Default to keychain (preferred backend)
+	return BackendKeychain
+}
+
+// macOS Keychain implementation using security CLI
+
+func getFromKeychain() (*oauth2.Token, error) {
+	cmd := exec.Command("security", "find-generic-password",
+		"-s", serviceName,
+		"-a", tokenKey,
+		"-w")
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from keychain: %w", err)
+	}
+
+	var token oauth2.Token
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &token); err != nil {
+		return nil, fmt.Errorf("failed to parse token from keychain: %w", err)
+	}
+
+	return &token, nil
+}
+
+func setInKeychain(token *oauth2.Token) error {
+	data, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("failed to serialize token: %w", err)
+	}
+
+	// Delete existing entry (ignore error if not exists)
+	_ = deleteFromKeychain()
+
+	// Add new entry
+	cmd := exec.Command("security", "add-generic-password",
+		"-s", serviceName,
+		"-a", tokenKey,
+		"-w", string(data),
+		"-U")
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to store in keychain: %w", err)
+	}
+
+	return nil
+}
+
+func deleteFromKeychain() error {
+	cmd := exec.Command("security", "delete-generic-password",
+		"-s", serviceName,
+		"-a", tokenKey)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete from keychain: %w", err)
+	}
+
+	return nil
+}

--- a/internal/keychain/keychain_linux.go
+++ b/internal/keychain/keychain_linux.go
@@ -1,0 +1,138 @@
+//go:build linux
+
+package keychain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// isSecretToolAvailable checks if secret-tool is installed
+func isSecretToolAvailable() bool {
+	_, err := exec.LookPath("secret-tool")
+	return err == nil
+}
+
+// getToken retrieves the OAuth token from Linux secret storage
+func getToken() (*oauth2.Token, error) {
+	if isSecretToolAvailable() {
+		token, err := getFromSecretTool()
+		if err == nil {
+			return token, nil
+		}
+	}
+
+	// Fall back to config file
+	return getFromConfigFile()
+}
+
+// setToken stores the OAuth token in Linux secret storage
+func setToken(token *oauth2.Token) error {
+	if isSecretToolAvailable() {
+		err := setInSecretTool(token)
+		if err == nil {
+			return nil
+		}
+		fmt.Printf("Warning: secret-tool storage failed, using config file: %v\n", err)
+	}
+
+	// Fall back to config file
+	return setInConfigFile(token)
+}
+
+// deleteToken removes the OAuth token from storage
+func deleteToken() error {
+	var secretErr, fileErr error
+
+	if isSecretToolAvailable() {
+		secretErr = deleteFromSecretTool()
+	}
+	fileErr = deleteFromConfigFile()
+
+	// Return secret-tool error if both fail, otherwise nil
+	if secretErr != nil && fileErr != nil {
+		return secretErr
+	}
+	return nil
+}
+
+// getStorageBackend returns the current storage backend
+func getStorageBackend() StorageBackend {
+	if isSecretToolAvailable() {
+		// Check if token exists in secret-tool
+		_, err := getFromSecretTool()
+		if err == nil {
+			return BackendSecretTool
+		}
+	}
+
+	// Check if token exists in file
+	_, err := getFromConfigFile()
+	if err == nil {
+		return BackendFile
+	}
+
+	// Default to secret-tool if available, otherwise file
+	if isSecretToolAvailable() {
+		return BackendSecretTool
+	}
+	return BackendFile
+}
+
+// Linux secret-tool implementation
+
+func getFromSecretTool() (*oauth2.Token, error) {
+	cmd := exec.Command("secret-tool", "lookup",
+		"service", serviceName,
+		"account", tokenKey)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from secret-tool: %w", err)
+	}
+
+	var token oauth2.Token
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &token); err != nil {
+		return nil, fmt.Errorf("failed to parse token from secret-tool: %w", err)
+	}
+
+	return &token, nil
+}
+
+func setInSecretTool(token *oauth2.Token) error {
+	data, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("failed to serialize token: %w", err)
+	}
+
+	// Delete existing entry (ignore error if not exists)
+	_ = deleteFromSecretTool()
+
+	cmd := exec.Command("secret-tool", "store",
+		"--label", "gmail-ro OAuth Token",
+		"service", serviceName,
+		"account", tokenKey)
+	cmd.Stdin = strings.NewReader(string(data))
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to store in secret-tool: %w", err)
+	}
+
+	return nil
+}
+
+func deleteFromSecretTool() error {
+	cmd := exec.Command("secret-tool", "clear",
+		"service", serviceName,
+		"account", tokenKey)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete from secret-tool: %w", err)
+	}
+
+	return nil
+}

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -1,0 +1,376 @@
+package keychain
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestConfigFile_TokenRoundTrip(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Create test token
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "test-refresh-token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour).Truncate(time.Second),
+	}
+
+	// Store token
+	err := setInConfigFile(token)
+	require.NoError(t, err)
+
+	// Retrieve token
+	retrieved, err := getFromConfigFile()
+	require.NoError(t, err)
+
+	assert.Equal(t, token.AccessToken, retrieved.AccessToken)
+	assert.Equal(t, token.RefreshToken, retrieved.RefreshToken)
+	assert.Equal(t, token.TokenType, retrieved.TokenType)
+	// Compare times with tolerance for JSON marshaling
+	assert.WithinDuration(t, token.Expiry, retrieved.Expiry, time.Second)
+}
+
+func TestConfigFile_Permissions(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	token := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+	}
+
+	err := setInConfigFile(token)
+	require.NoError(t, err)
+
+	// Check file permissions
+	path := filepath.Join(tmpDir, serviceName, tokenFile)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	// Verify 0600 permissions (read/write for owner only)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestConfigFile_DirectoryPermissions(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	token := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+	}
+
+	err := setInConfigFile(token)
+	require.NoError(t, err)
+
+	// Check directory permissions
+	dir := filepath.Join(tmpDir, serviceName)
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	// Verify 0700 permissions (read/write/execute for owner only)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+}
+
+func TestConfigFile_NotFound(t *testing.T) {
+	// Create temp directory (empty)
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	_, err := getFromConfigFile()
+	assert.ErrorIs(t, err, ErrTokenNotFound)
+}
+
+func TestConfigFile_InvalidJSON(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Create config directory
+	configDir := filepath.Join(tmpDir, serviceName)
+	err := os.MkdirAll(configDir, 0700)
+	require.NoError(t, err)
+
+	// Write invalid JSON
+	path := filepath.Join(configDir, tokenFile)
+	err = os.WriteFile(path, []byte("invalid json"), 0600)
+	require.NoError(t, err)
+
+	_, err = getFromConfigFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse token file")
+}
+
+func TestConfigFile_Overwrite(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Store first token
+	token1 := &oauth2.Token{
+		AccessToken: "first-token",
+		TokenType:   "Bearer",
+	}
+	err := setInConfigFile(token1)
+	require.NoError(t, err)
+
+	// Store second token
+	token2 := &oauth2.Token{
+		AccessToken: "second-token",
+		TokenType:   "Bearer",
+	}
+	err = setInConfigFile(token2)
+	require.NoError(t, err)
+
+	// Retrieve should return second token
+	retrieved, err := getFromConfigFile()
+	require.NoError(t, err)
+	assert.Equal(t, "second-token", retrieved.AccessToken)
+}
+
+func TestConfigFile_Delete(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Store token
+	token := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+	}
+	err := setInConfigFile(token)
+	require.NoError(t, err)
+
+	// Delete token
+	err = deleteFromConfigFile()
+	require.NoError(t, err)
+
+	// Should be gone
+	_, err = getFromConfigFile()
+	assert.ErrorIs(t, err, ErrTokenNotFound)
+}
+
+func TestConfigFile_DeleteNonExistent(t *testing.T) {
+	// Create temp directory (empty)
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Delete should not error on non-existent file
+	err := deleteFromConfigFile()
+	assert.NoError(t, err)
+}
+
+func TestMigrateFromFile_NoFile(t *testing.T) {
+	// Migration should succeed (no-op) when file doesn't exist
+	err := MigrateFromFile("/nonexistent/path/token.json")
+	assert.NoError(t, err)
+}
+
+func TestMigrateFromFile_InvalidJSON(t *testing.T) {
+	// This test verifies that invalid JSON in a token file causes an error
+	// when migration is attempted without existing secure storage.
+	//
+	// Note: On macOS, if there's already a token in the system keychain,
+	// MigrateFromFile will skip reading the file (already migrated).
+	// This is expected behavior - the test validates the JSON parsing path
+	// when no secure storage token exists.
+
+	tmpDir := t.TempDir()
+	configDir := t.TempDir()
+
+	// Override config directory so we don't find existing tokens
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", configDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Create temp file with invalid JSON
+	tokenPath := filepath.Join(tmpDir, "token.json")
+	err := os.WriteFile(tokenPath, []byte("invalid json"), 0600)
+	require.NoError(t, err)
+
+	// If secure storage has a token (e.g., from real keychain), migration is skipped
+	// In that case, we test the direct file parsing instead
+	if IsSecureStorage() && HasStoredToken() {
+		t.Skip("Secure storage already has a token, migration would be skipped")
+	}
+
+	err = MigrateFromFile(tokenPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse token file")
+}
+
+func TestMigrateFromFile_Success(t *testing.T) {
+	// This test verifies that migration from file to storage works correctly.
+	// On macOS, if there's already a token in the system keychain,
+	// migration is skipped (considered already migrated).
+
+	// Skip if secure storage already has a token
+	if IsSecureStorage() && HasStoredToken() {
+		t.Skip("Secure storage already has a token, migration would be skipped")
+	}
+
+	// Create temp directories
+	tmpDir := t.TempDir()
+	configDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", configDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Create valid token file
+	token := &oauth2.Token{
+		AccessToken:  "migrated-token",
+		RefreshToken: "migrated-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+	tokenPath := filepath.Join(tmpDir, "token.json")
+	data, err := json.Marshal(token)
+	require.NoError(t, err)
+	err = os.WriteFile(tokenPath, data, 0600)
+	require.NoError(t, err)
+
+	// Run migration
+	err = MigrateFromFile(tokenPath)
+	require.NoError(t, err)
+
+	// Verify token was stored (in config file since we use temp config dir)
+	retrieved, err := getFromConfigFile()
+	require.NoError(t, err)
+	assert.Equal(t, "migrated-token", retrieved.AccessToken)
+
+	// Verify backup was created
+	backupPath := tokenPath + ".backup"
+	_, err = os.Stat(backupPath)
+	assert.NoError(t, err)
+
+	// Verify original was removed
+	_, err = os.Stat(tokenPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestHasStoredToken_ConfigFile(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Override config directory for test
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	// Test file-based storage specifically
+	// Note: HasStoredToken() may find tokens in system keychain on macOS,
+	// so we test the underlying file functions directly
+
+	// Should return error when no token file
+	_, err := getFromConfigFile()
+	assert.ErrorIs(t, err, ErrTokenNotFound)
+
+	// Store a token in config file
+	token := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+	}
+	err = setInConfigFile(token)
+	require.NoError(t, err)
+
+	// Should successfully retrieve from config file
+	retrieved, err := getFromConfigFile()
+	require.NoError(t, err)
+	assert.Equal(t, "test-token", retrieved.AccessToken)
+}
+
+func TestGetStorageBackend(t *testing.T) {
+	// Just verify it returns a valid backend
+	backend := GetStorageBackend()
+	assert.Contains(t, []StorageBackend{BackendKeychain, BackendSecretTool, BackendFile}, backend)
+}
+
+func TestIsSecureStorage(t *testing.T) {
+	// This will vary by platform - just verify it returns a bool
+	result := IsSecureStorage()
+	assert.IsType(t, true, result)
+}
+
+func TestTokenFilePath(t *testing.T) {
+	// Test with XDG_CONFIG_HOME set
+	tmpDir := t.TempDir()
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	path, err := tokenFilePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmpDir, serviceName, tokenFile), path)
+}
+
+func TestConfigDir(t *testing.T) {
+	// Test with XDG_CONFIG_HOME set
+	tmpDir := t.TempDir()
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	dir, err := configDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmpDir, serviceName), dir)
+}
+
+func TestConfigDir_NoXDG(t *testing.T) {
+	// Test without XDG_CONFIG_HOME
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", originalXDG)
+
+	dir, err := configDir()
+	require.NoError(t, err)
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".config", serviceName), dir)
+}

--- a/internal/keychain/token_source.go
+++ b/internal/keychain/token_source.go
@@ -1,0 +1,58 @@
+package keychain
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"golang.org/x/oauth2"
+)
+
+// PersistentTokenSource wraps a TokenSource and persists refreshed tokens.
+// This solves the problem where oauth2's automatic token refresh doesn't
+// persist the new token to storage.
+type PersistentTokenSource struct {
+	mu      sync.Mutex
+	base    oauth2.TokenSource
+	current *oauth2.Token
+}
+
+// NewPersistentTokenSource creates a TokenSource that persists refreshed tokens.
+// When the underlying oauth2 package refreshes an expired token, this wrapper
+// detects the change and saves the new token to secure storage.
+func NewPersistentTokenSource(config *oauth2.Config, initial *oauth2.Token) oauth2.TokenSource {
+	// Create base token source that handles refresh
+	base := config.TokenSource(context.Background(), initial)
+
+	return &PersistentTokenSource{
+		base:    base,
+		current: initial,
+	}
+}
+
+// Token returns a valid token, refreshing and persisting if necessary.
+// This method is safe for concurrent use.
+func (p *PersistentTokenSource) Token() (*oauth2.Token, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Get token (may trigger refresh)
+	token, err := p.base.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if token changed (refresh occurred)
+	if p.current == nil || token.AccessToken != p.current.AccessToken {
+		// Persist the new token
+		if err := SetToken(token); err != nil {
+			// Log warning but don't fail - token is still valid in memory
+			// User will need to re-auth on next run if this persists
+			fmt.Fprintf(os.Stderr, "Warning: failed to persist refreshed token: %v\n", err)
+		}
+		p.current = token
+	}
+
+	return token, nil
+}


### PR DESCRIPTION
## Summary

Add secure token storage using platform-native mechanisms instead of plaintext JSON files.

## Changes

### New Package: `internal/keychain`
- **keychain.go**: Core interface with file-based fallback storage
- **keychain_darwin.go**: macOS Keychain support via `security` CLI
- **keychain_linux.go**: Linux secret-tool support with file fallback
- **token_source.go**: `PersistentTokenSource` wrapper that saves refreshed tokens
- **keychain_test.go**: Comprehensive unit tests

### Modified Files
- **internal/gmail/client.go**: Integrate keychain for token storage
- **CLAUDE.md**: Document keychain storage and troubleshooting

## Features

1. **Platform-native secure storage**
   - macOS: System Keychain
   - Linux: libsecret (secret-tool) when available
   - Fallback: Config file with 0600 permissions

2. **Auto-migration**: Existing `token.json` files migrate to secure storage on first run, with backup

3. **Token refresh persistence**: Wrapped TokenSource saves refreshed tokens automatically (fixes tokens expiring between CLI sessions)

## Verification

```bash
# Build and test
make verify

# Test migration (if token.json exists)
./gmail-ro search "is:inbox" --max 1
# Should print migration notice if upgrading

# Verify keychain storage (macOS)
security find-generic-password -s gmail-ro -a oauth_token -w | jq .
```

## Test plan

- [x] Unit tests for file storage operations
- [x] Unit tests for migration scenarios
- [x] Tests skip gracefully when system keychain has existing tokens
- [x] All existing tests pass

Closes #25