### PR TITLE
feat(cli): add init and config commands for improved OAuth setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ gmail-ro/
 ├── main.go                     # Entry point
 ├── cmd/
 │   ├── root.go                 # Root command, version command
+│   ├── init.go                 # Guided OAuth setup command
+│   ├── config.go               # Config show/test/clear subcommands
 │   ├── search.go               # Search messages command
 │   ├── read.go                 # Read single message command
 │   ├── thread.go               # Read conversation thread command
@@ -72,6 +74,33 @@ gmail-ro/
 ├── Makefile                    # Build, test, lint targets
 └── go.mod                      # Module: github.com/open-cli-collective/gmail-ro
 ```
+
+## Setup Commands
+
+The CLI provides commands for guided setup and configuration management:
+
+```bash
+# Guided OAuth setup with clear instructions
+gmail-ro init
+
+# Setup without connectivity verification
+gmail-ro init --no-verify
+
+# Check configuration status (credentials, token, email)
+gmail-ro config show
+
+# Test Gmail API connectivity
+gmail-ro config test
+
+# Clear stored OAuth token (forces re-authentication)
+gmail-ro config clear
+```
+
+The `init` command improves the OAuth flow by:
+- Checking for `credentials.json` and providing setup instructions if missing
+- Accepting either the full localhost redirect URL or just the authorization code
+- Explaining that the localhost error page is expected behavior
+- Verifying connectivity after authentication
 
 ## Key Patterns
 
@@ -271,24 +300,27 @@ mv ~/Downloads/client_secret_*.json ~/.config/gmail-ro/credentials.json
 
 ### "Token has been expired or revoked"
 
-Delete token and re-authenticate:
+Clear the token and re-authenticate:
+```bash
+gmail-ro config clear
+gmail-ro init
+```
+
+Alternatively, delete the token manually:
 
 **macOS (token in Keychain):**
 ```bash
 security delete-generic-password -s gmail-ro -a oauth_token
-gmail-ro search "test"  # Will prompt for re-auth
 ```
 
 **Linux (token in secret-tool):**
 ```bash
 secret-tool clear service gmail-ro account oauth_token
-gmail-ro search "test"  # Will prompt for re-auth
 ```
 
 **File-based storage:**
 ```bash
 rm ~/.config/gmail-ro/token.json
-gmail-ro search "test"  # Will prompt for re-auth
 ```
 
 ### "Access blocked: This app's request is invalid"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/piekstra/gmail-ro/internal/gmail"
+	"github.com/piekstra/gmail-ro/internal/keychain"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configTestCmd)
+	configCmd.AddCommand(configClearCmd)
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage gmail-ro configuration",
+	Long:  "View and manage gmail-ro configuration and authentication status.",
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Display configuration status",
+	Long: `Display the current configuration status including:
+- Credentials file location and status
+- OAuth token storage location and status
+- Token expiration time (if available)`,
+	Args: cobra.NoArgs,
+	RunE: runConfigShow,
+}
+
+var configTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test Gmail API connectivity",
+	Long: `Test the Gmail API connection with current credentials.
+This verifies that the OAuth token is valid and the API is accessible.`,
+	Args: cobra.NoArgs,
+	RunE: runConfigTest,
+}
+
+var configClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Remove stored OAuth token",
+	Long: `Remove the stored OAuth token, forcing re-authentication on next use.
+
+Note: This only removes the OAuth token (access/refresh tokens).
+The credentials.json file (OAuth client config) is not removed.`,
+	Args: cobra.NoArgs,
+	RunE: runConfigClear,
+}
+
+func runConfigShow(cmd *cobra.Command, args []string) error {
+	// Check credentials file
+	credPath, err := gmail.GetCredentialsPath()
+	if err != nil {
+		return fmt.Errorf("failed to get credentials path: %w", err)
+	}
+
+	credStatus := "OK"
+	if _, err := os.Stat(credPath); os.IsNotExist(err) {
+		credStatus = "Not found"
+	}
+	fmt.Printf("Credentials: %s (%s)\n", credPath, credStatus)
+
+	// Check token
+	tokenStatus := "Not found"
+	var tokenExpiry string
+
+	if keychain.HasStoredToken() {
+		backend := keychain.GetStorageBackend()
+		tokenStatus = string(backend)
+
+		// Try to get token expiry
+		if token, err := keychain.GetToken(); err == nil && !token.Expiry.IsZero() {
+			if token.Expiry.Before(time.Now()) {
+				tokenExpiry = fmt.Sprintf("Expired at %s", token.Expiry.Format(time.RFC3339))
+			} else {
+				remaining := time.Until(token.Expiry).Round(time.Minute)
+				tokenExpiry = fmt.Sprintf("Expires %s (in %s)", token.Expiry.Format(time.RFC3339), remaining)
+			}
+		}
+	}
+
+	fmt.Printf("Token:       %s\n", tokenStatus)
+	if tokenExpiry != "" {
+		fmt.Printf("Expiry:      %s\n", tokenExpiry)
+	}
+
+	// Check if secure storage is being used
+	if keychain.IsSecureStorage() {
+		fmt.Println("Security:    Secure storage (system keychain)")
+	} else if keychain.HasStoredToken() {
+		fmt.Println("Security:    File storage (0600 permissions)")
+	}
+
+	// Show email if we can get it without triggering auth
+	if keychain.HasStoredToken() && credStatus == "OK" {
+		if client, err := newGmailClient(); err == nil {
+			if profile, err := client.Service.Users.GetProfile("me").Do(); err == nil {
+				fmt.Printf("Email:       %s\n", profile.EmailAddress)
+			}
+		}
+	}
+
+	// Show help if not fully configured
+	if credStatus == "Not found" || tokenStatus == "Not found" {
+		fmt.Println()
+		fmt.Println("Run 'gmail-ro init' to complete setup.")
+	}
+
+	return nil
+}
+
+func runConfigTest(cmd *cobra.Command, args []string) error {
+	fmt.Println("Testing Gmail API connection...")
+	fmt.Println()
+
+	// Check token exists
+	if !keychain.HasStoredToken() {
+		fmt.Println("  OAuth token: Not found")
+		fmt.Println()
+		fmt.Println("Run 'gmail-ro init' to authenticate.")
+		return fmt.Errorf("no OAuth token found")
+	}
+	fmt.Println("  OAuth token: Found")
+
+	// Try to create client (tests token validity)
+	client, err := newGmailClient()
+	if err != nil {
+		fmt.Println("  Token valid: FAILED")
+		fmt.Println()
+		fmt.Println("Token may be expired or revoked.")
+		fmt.Println("Run 'gmail-ro config clear' then 'gmail-ro init' to re-authenticate.")
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	fmt.Println("  Token valid: OK")
+
+	// Test API access
+	profile, err := client.Service.Users.GetProfile("me").Do()
+	if err != nil {
+		fmt.Println("  Gmail API:   FAILED")
+		return fmt.Errorf("failed to access Gmail API: %w", err)
+	}
+	fmt.Println("  Gmail API:   OK")
+	fmt.Printf("  Messages:    %d total\n", profile.MessagesTotal)
+
+	fmt.Println()
+	fmt.Printf("Authenticated as: %s\n", profile.EmailAddress)
+
+	return nil
+}
+
+func runConfigClear(cmd *cobra.Command, args []string) error {
+	if !keychain.HasStoredToken() {
+		fmt.Println("No OAuth token found to clear.")
+		return nil
+	}
+
+	backend := keychain.GetStorageBackend()
+
+	if err := keychain.DeleteToken(); err != nil {
+		return fmt.Errorf("failed to clear token: %w", err)
+	}
+
+	fmt.Printf("Cleared OAuth token from %s.\n", backend)
+	fmt.Println()
+	fmt.Println("Note: credentials.json is not removed (contains OAuth client config, not user data).")
+	fmt.Println("Run 'gmail-ro init' to re-authenticate.")
+
+	return nil
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "config", configCmd.Use)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, configCmd.Short)
+	})
+
+	t.Run("has subcommands", func(t *testing.T) {
+		subcommands := configCmd.Commands()
+		assert.GreaterOrEqual(t, len(subcommands), 3)
+
+		var names []string
+		for _, cmd := range subcommands {
+			names = append(names, cmd.Name())
+		}
+		assert.Contains(t, names, "show")
+		assert.Contains(t, names, "test")
+		assert.Contains(t, names, "clear")
+	})
+}
+
+func TestConfigShowCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "show", configShowCmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := configShowCmd.Args(configShowCmd, []string{})
+		assert.NoError(t, err)
+
+		err = configShowCmd.Args(configShowCmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, configShowCmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, configShowCmd.Long)
+	})
+}
+
+func TestConfigTestCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "test", configTestCmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := configTestCmd.Args(configTestCmd, []string{})
+		assert.NoError(t, err)
+
+		err = configTestCmd.Args(configTestCmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, configTestCmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, configTestCmd.Long)
+	})
+}
+
+func TestConfigClearCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "clear", configClearCmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := configClearCmd.Args(configClearCmd, []string{})
+		assert.NoError(t, err)
+
+		err = configClearCmd.Args(configClearCmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, configClearCmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, configClearCmd.Long)
+		assert.Contains(t, configClearCmd.Long, "token")
+	})
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -136,10 +136,12 @@ func extractAuthCode(input string) string {
 	// If it looks like a URL, try to extract the code parameter
 	if strings.HasPrefix(input, "http://localhost") || strings.HasPrefix(input, "https://localhost") {
 		if u, err := url.Parse(input); err == nil {
-			if code := u.Query().Get("code"); code != "" {
-				return code
-			}
+			// Return the code if present, empty string if not
+			// (e.g., URL has ?error=access_denied instead of ?code=...)
+			return u.Query().Get("code")
 		}
+		// URL parsing failed, return empty
+		return ""
 	}
 
 	// Otherwise treat as raw code

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/piekstra/gmail-ro/internal/gmail"
+	"github.com/piekstra/gmail-ro/internal/keychain"
+	"github.com/spf13/cobra"
+)
+
+var initNoVerify bool
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().BoolVar(&initNoVerify, "no-verify", false, "Skip connectivity verification after setup")
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Set up Gmail API authentication",
+	Long: `Guided setup for Gmail API OAuth authentication.
+
+This command walks you through the OAuth flow with clear instructions.
+After setup, you can use other commands like 'search', 'read', and 'thread'.
+
+Prerequisites:
+  1. Create a Google Cloud project at https://console.cloud.google.com
+  2. Enable the Gmail API
+  3. Create OAuth 2.0 credentials (Desktop app type)
+  4. Download the credentials JSON file
+  5. Save it to ~/.config/gmail-ro/credentials.json`,
+	Args: cobra.NoArgs,
+	RunE: runInit,
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	// Step 1: Check for credentials.json
+	credPath, err := gmail.GetCredentialsPath()
+	if err != nil {
+		return fmt.Errorf("failed to get credentials path: %w", err)
+	}
+
+	if _, err := os.Stat(credPath); os.IsNotExist(err) {
+		fmt.Println("Credentials file not found.")
+		fmt.Println()
+		printCredentialsInstructions(credPath)
+		return fmt.Errorf("credentials file not found at %s", credPath)
+	}
+	fmt.Printf("Credentials: %s\n", credPath)
+
+	// Step 2: Load OAuth config
+	config, err := gmail.GetOAuthConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load OAuth config: %w", err)
+	}
+
+	// Step 3: Check if already authenticated
+	if keychain.HasStoredToken() {
+		fmt.Println("Token:       Already authenticated")
+		fmt.Println()
+
+		if !initNoVerify {
+			return verifyConnectivity()
+		}
+
+		fmt.Println("Setup complete! Try: gmail-ro search \"is:unread\"")
+		return nil
+	}
+
+	// Step 4: Guide through OAuth flow
+	fmt.Println("Token:       Not found - starting OAuth flow")
+	fmt.Println()
+
+	authURL := gmail.GetAuthURL(config)
+	fmt.Println("Open this URL in your browser:")
+	fmt.Println()
+	fmt.Println(authURL)
+	fmt.Println()
+	fmt.Println("After clicking 'Allow', your browser will redirect to a localhost URL.")
+	fmt.Println("This will show an error - that's expected!")
+	fmt.Println()
+	fmt.Println("Copy the ENTIRE URL from your browser's address bar and paste it here,")
+	fmt.Println("or just paste the 'code' parameter value:")
+	fmt.Println()
+	fmt.Print("> ")
+
+	// Read the full line (code may contain special characters)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	code := extractAuthCode(input)
+	if code == "" {
+		return fmt.Errorf("no authorization code found in input")
+	}
+
+	// Step 5: Exchange code for token
+	fmt.Println()
+	fmt.Println("Exchanging authorization code...")
+
+	ctx := context.Background()
+	token, err := gmail.ExchangeAuthCode(ctx, config, code)
+	if err != nil {
+		return fmt.Errorf("failed to exchange authorization code: %w", err)
+	}
+
+	// Step 6: Save token
+	if err := keychain.SetToken(token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
+	}
+	fmt.Printf("Token saved to: %s\n", keychain.GetStorageBackend())
+
+	// Step 7: Verify connectivity (unless --no-verify)
+	if !initNoVerify {
+		fmt.Println()
+		return verifyConnectivity()
+	}
+
+	fmt.Println()
+	fmt.Println("Setup complete! Try: gmail-ro search \"is:unread\"")
+	return nil
+}
+
+// extractAuthCode extracts the authorization code from user input.
+// It accepts either a full localhost redirect URL or just the code value.
+func extractAuthCode(input string) string {
+	input = strings.TrimSpace(input)
+
+	// If it looks like a URL, try to extract the code parameter
+	if strings.HasPrefix(input, "http://localhost") || strings.HasPrefix(input, "https://localhost") {
+		if u, err := url.Parse(input); err == nil {
+			if code := u.Query().Get("code"); code != "" {
+				return code
+			}
+		}
+	}
+
+	// Otherwise treat as raw code
+	return input
+}
+
+// verifyConnectivity tests the Gmail API connection
+func verifyConnectivity() error {
+	fmt.Println("Verifying Gmail API connection...")
+
+	client, err := newGmailClient()
+	if err != nil {
+		fmt.Println("  OAuth token: FAILED")
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	fmt.Println("  OAuth token: OK")
+
+	// Get profile to verify connectivity and get email address
+	profile, err := client.Service.Users.GetProfile("me").Do()
+	if err != nil {
+		fmt.Println("  Gmail API:   FAILED")
+		return fmt.Errorf("failed to access Gmail API: %w", err)
+	}
+	fmt.Println("  Gmail API:   OK")
+	fmt.Printf("  Messages:    %d total\n", profile.MessagesTotal)
+	fmt.Println()
+	fmt.Printf("Authenticated as: %s\n", profile.EmailAddress)
+	fmt.Println()
+	fmt.Println("Setup complete! Try: gmail-ro search \"is:unread\"")
+	return nil
+}
+
+func printCredentialsInstructions(credPath string) {
+	fmt.Println("To set up Gmail API credentials:")
+	fmt.Println()
+	fmt.Println("1. Go to https://console.cloud.google.com")
+	fmt.Println("2. Create a new project (or select an existing one)")
+	fmt.Println("3. Enable the Gmail API:")
+	fmt.Println("   - Go to 'APIs & Services' > 'Library'")
+	fmt.Println("   - Search for 'Gmail API' and enable it")
+	fmt.Println("4. Create OAuth credentials:")
+	fmt.Println("   - Go to 'APIs & Services' > 'Credentials'")
+	fmt.Println("   - Click 'Create Credentials' > 'OAuth client ID'")
+	fmt.Println("   - Select 'Desktop app' as application type")
+	fmt.Println("   - Download the JSON file")
+	fmt.Printf("5. Save the downloaded file to:\n   %s\n", credPath)
+	fmt.Println()
+	fmt.Println("Then run 'gmail-ro init' again.")
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCommand(t *testing.T) {
+	t.Run("has correct use", func(t *testing.T) {
+		assert.Equal(t, "init", initCmd.Use)
+	})
+
+	t.Run("requires no arguments", func(t *testing.T) {
+		err := initCmd.Args(initCmd, []string{})
+		assert.NoError(t, err)
+
+		err = initCmd.Args(initCmd, []string{"extra"})
+		assert.Error(t, err)
+	})
+
+	t.Run("has no-verify flag", func(t *testing.T) {
+		flag := initCmd.Flags().Lookup("no-verify")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "false", flag.DefValue)
+	})
+
+	t.Run("has short description", func(t *testing.T) {
+		assert.NotEmpty(t, initCmd.Short)
+	})
+
+	t.Run("has long description", func(t *testing.T) {
+		assert.NotEmpty(t, initCmd.Long)
+		assert.Contains(t, initCmd.Long, "OAuth")
+	})
+}
+
+func TestExtractAuthCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "raw code",
+			input:    "4/0AQSTgQxyz123",
+			expected: "4/0AQSTgQxyz123",
+		},
+		{
+			name:     "localhost URL with code",
+			input:    "http://localhost/?code=4/0AQSTgQxyz123&scope=email",
+			expected: "4/0AQSTgQxyz123",
+		},
+		{
+			name:     "localhost URL with port",
+			input:    "http://localhost:8080/?code=ABC123&scope=email",
+			expected: "ABC123",
+		},
+		{
+			name:     "https localhost URL",
+			input:    "https://localhost/?code=SecureCode456",
+			expected: "SecureCode456",
+		},
+		{
+			name:     "URL without code param",
+			input:    "http://localhost/?error=access_denied",
+			expected: "",
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    "  4/0AQSTgQxyz123  \n",
+			expected: "4/0AQSTgQxyz123",
+		},
+		{
+			name:     "whitespace trimmed from URL",
+			input:    "  http://localhost/?code=TrimMe  \n",
+			expected: "TrimMe",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "   \n\t  ",
+			expected: "",
+		},
+		{
+			name:     "non-localhost URL treated as raw code",
+			input:    "http://example.com/?code=NotExtracted",
+			expected: "http://example.com/?code=NotExtracted",
+		},
+		{
+			name:     "code with special characters",
+			input:    "http://localhost/?code=4/P-abc_123.xyz~456",
+			expected: "4/P-abc_123.xyz~456",
+		},
+		{
+			name:     "URL encoded code",
+			input:    "http://localhost/?code=4%2F0AQSTgQ",
+			expected: "4/0AQSTgQ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractAuthCode(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -191,3 +191,40 @@ func (c *Client) GetLabels() []*gmail.Label {
 	}
 	return labels
 }
+
+// GetConfigDir returns the configuration directory path
+func GetConfigDir() (string, error) {
+	return getConfigDir()
+}
+
+// GetCredentialsPath returns the path to credentials.json
+func GetCredentialsPath() (string, error) {
+	dir, err := getConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, credentialsFile), nil
+}
+
+// GetOAuthConfig loads OAuth config from credentials file
+func GetOAuthConfig() (*oauth2.Config, error) {
+	credPath, err := GetCredentialsPath()
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(credPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read credentials file: %w", err)
+	}
+	return google.ConfigFromJSON(b, gmail.GmailReadonlyScope)
+}
+
+// ExchangeAuthCode exchanges an authorization code for a token
+func ExchangeAuthCode(ctx context.Context, config *oauth2.Config, code string) (*oauth2.Token, error) {
+	return config.Exchange(ctx, code)
+}
+
+// GetAuthURL returns the OAuth authorization URL
+func GetAuthURL(config *oauth2.Config) string {
+	return config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+}


### PR DESCRIPTION
## Summary
- Add `gmail-ro init` command for guided OAuth setup that accepts either full localhost redirect URL or just the authorization code
- Add `gmail-ro config show` to display configuration status
- Add `gmail-ro config test` to verify Gmail API connectivity
- Add `gmail-ro config clear` to remove stored OAuth token
- Export helper functions from internal/gmail/client.go for use by commands
- Update CLAUDE.md with documentation for new commands

Closes #24

## Test plan
- [ ] Run `make verify` to ensure all tests pass
- [ ] Test `gmail-ro init --help` shows correct usage
- [ ] Test `gmail-ro config show` displays status
- [ ] Test `gmail-ro config test` with valid token
- [ ] Test `gmail-ro config clear` removes token

🤖 Generated with [Claude Code](https://claude.com/claude-code)