### PR TITLE
chore: migrate module path from piekstra to open-cli-collective

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -w -X github.com/piekstra/gmail-ro/cmd.Version={{.Version}}
+      - -s -w -X github.com/open-cli-collective/gmail-ro/cmd.Version={{.Version}}
 
 archives:
   - id: default

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ VERSION?=dev
 COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-LDFLAGS=-ldflags "-X github.com/piekstra/gmail-ro/cmd.Version=$(VERSION) \
-	-X github.com/piekstra/gmail-ro/cmd.Commit=$(COMMIT) \
-	-X github.com/piekstra/gmail-ro/cmd.BuildDate=$(BUILD_DATE)"
+LDFLAGS=-ldflags "-X github.com/open-cli-collective/gmail-ro/cmd.Version=$(VERSION) \
+	-X github.com/open-cli-collective/gmail-ro/cmd.Commit=$(COMMIT) \
+	-X github.com/open-cli-collective/gmail-ro/cmd.BuildDate=$(BUILD_DATE)"
 
 build:
 	go build $(LDFLAGS) -o $(BINARY_NAME) .

--- a/cmd/attachments_download.go
+++ b/cmd/attachments_download.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
-	ziputil "github.com/piekstra/gmail-ro/internal/zip"
+	"github.com/open-cli-collective/gmail-ro/internal/gmail"
+	ziputil "github.com/open-cli-collective/gmail-ro/internal/zip"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
-	"github.com/piekstra/gmail-ro/internal/keychain"
+	"github.com/open-cli-collective/gmail-ro/internal/gmail"
+	"github.com/open-cli-collective/gmail-ro/internal/keychain"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
-	"github.com/piekstra/gmail-ro/internal/keychain"
+	"github.com/open-cli-collective/gmail-ro/internal/gmail"
+	"github.com/open-cli-collective/gmail-ro/internal/keychain"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/piekstra/gmail-ro/internal/gmail"
+	"github.com/open-cli-collective/gmail-ro/internal/gmail"
 )
 
 // newGmailClient creates and returns a new Gmail client

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/piekstra/gmail-ro
+module github.com/open-cli-collective/gmail-ro
 
 go 1.21
 

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/piekstra/gmail-ro/internal/keychain"
+	"github.com/open-cli-collective/gmail-ro/internal/keychain"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/gmail/v1"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/piekstra/gmail-ro/cmd"
+import "github.com/open-cli-collective/gmail-ro/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary

Migrate Go module path and all imports from `github.com/piekstra/gmail-ro` to `github.com/open-cli-collective/gmail-ro` to reflect the repository's new organization home.

## Changes

- **go.mod**: Updated module declaration
- **Build config**: Updated Makefile, .goreleaser.yaml
- **Go source files**: Updated all import statements (6 files)

## Test Plan

- [x] `go mod tidy` succeeds
- [x] `make verify` passes (format, lint, test)
- [x] No piekstra references remaining in codebase

Closes #62