### PR TITLE
feat: add Linux distribution support (Snap, APT, RPM)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,3 +249,41 @@ jobs:
 
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir
+
+  snap:
+    if: false  # Temporarily disabled - waiting for personal-files interface approval
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Publish to Snapcraft Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable
+
+  linux-packages:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger linux-packages repo update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LINUX_PACKAGES_DISPATCH_TOKEN }}
+          repository: open-cli-collective/linux-packages
+          event-type: package-release
+          client-payload: |-
+            {
+              "package": "gmro",
+              "version": "${{ github.ref_name }}",
+              "repo": "open-cli-collective/gmail-ro"
+            }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,23 @@ archives:
       - LICENSE
       - README.md
 
+# Linux packages (.deb and .rpm)
+nfpms:
+  - id: gmro
+    package_name: gmro
+    vendor: Open CLI Collective
+    homepage: https://github.com/open-cli-collective/gmail-ro
+    maintainer: Open CLI Collective <https://github.com/open-cli-collective>
+    description: Read-only command-line interface for Gmail
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/licenses/gmro/LICENSE
+
 checksum:
   name_template: "checksums.txt"
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,86 @@ A read-only command-line interface for Gmail. Search, read, and view email threa
 
 ## Installation
 
-### Homebrew (macOS/Linux)
+### macOS
+
+**Homebrew (recommended)**
 
 ```bash
-brew tap open-cli-collective/tap
-brew install gmail-readonly
+brew install open-cli-collective/tap/gmail-readonly
 ```
 
-### Download Binary
+> Note: This installs from our third-party tap.
 
-Download the latest release for your platform from the [Releases page](https://github.com/open-cli-collective/gmail-ro/releases).
+---
 
-### Build from Source
+### Windows
+
+**Chocolatey**
+
+```powershell
+choco install gmail-readonly
+```
+
+**Winget**
+
+```powershell
+winget install OpenCLICollective.gmail-readonly
+```
+
+---
+
+### Linux
+
+**Snap**
+
+```bash
+sudo snap install ocli-gmail
+```
+
+> Note: After installation, the command is available as `gmro`.
+
+**APT (Debian/Ubuntu)**
+
+```bash
+# Add the GPG key
+curl -fsSL https://open-cli-collective.github.io/linux-packages/keys/gpg.asc | sudo gpg --dearmor -o /usr/share/keyrings/open-cli-collective.gpg
+
+# Add the repository
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/open-cli-collective.gpg] https://open-cli-collective.github.io/linux-packages/apt stable main" | sudo tee /etc/apt/sources.list.d/open-cli-collective.list
+
+# Install
+sudo apt update
+sudo apt install gmro
+```
+
+> Note: This is our third-party APT repository, not official Debian/Ubuntu repos.
+
+**DNF/YUM (Fedora/RHEL/CentOS)**
+
+```bash
+# Add the repository
+sudo tee /etc/yum.repos.d/open-cli-collective.repo << 'EOF'
+[open-cli-collective]
+name=Open CLI Collective
+baseurl=https://open-cli-collective.github.io/linux-packages/rpm
+enabled=1
+gpgcheck=1
+gpgkey=https://open-cli-collective.github.io/linux-packages/keys/gpg.asc
+EOF
+
+# Install
+sudo dnf install gmro
+```
+
+> Note: This is our third-party RPM repository, not official Fedora/RHEL repos.
+
+**Binary download**
+
+Download `.deb`, `.rpm`, or `.tar.gz` from the [Releases page](https://github.com/open-cli-collective/gmail-ro/releases).
+
+---
+
+### From Source
 
 ```bash
 go install github.com/open-cli-collective/gmail-ro@latest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,58 @@
+name: ocli-gmail
+base: core22
+version: git
+summary: Read-only command-line interface for Gmail
+description: |
+  gmro is a read-only CLI for Gmail.
+
+  Features:
+  - Search messages using Gmail search syntax
+  - Read messages and view threads
+  - List and download attachments
+  - JSON output for scripting
+  - Uses gmail.readonly scope exclusively
+
+  Run 'gmro init' to set up OAuth credentials.
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+plugs:
+  dot-config-gmail-readonly:
+    interface: personal-files
+    read:
+      - $HOME/.config/gmail-readonly
+    write:
+      - $HOME/.config/gmail-readonly
+
+apps:
+  ocli-gmail:
+    command: bin/gmro
+    plugs:
+      - home
+      - network
+      - dot-config-gmail-readonly
+    aliases:
+      - gmro
+
+parts:
+  gmro:
+    plugin: go
+    source: .
+    build-snaps:
+      - go/1.24/stable
+    build-environment:
+      - CGO_ENABLED: "0"
+    override-build: |
+      # Get version from git
+      VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
+      # Build with ldflags
+      go build -o $SNAPCRAFT_PART_INSTALL/bin/gmro \
+        -ldflags "-s -w \
+          -X github.com/open-cli-collective/gmail-ro/cmd.Version=${VERSION}" \
+        .


### PR DESCRIPTION
## Summary

Add Linux distribution support for gmail-ro, enabling users to install via:
- **Snap Store** (as `ocli-gmail`, aliased to `gmro`)
- **APT** (Debian/Ubuntu) via open-cli-collective linux-packages repo
- **DNF/YUM** (Fedora/RHEL/CentOS) via open-cli-collective linux-packages repo
- **Direct download** of `.deb` and `.rpm` packages from GitHub Releases

## Changes

- **`.goreleaser.yaml`**: Added `nfpms` section to generate `.deb` and `.rpm` packages
- **`snap/snapcraft.yaml`**: New file for Snap package definition with:
  - `personal-files` interface for `~/.config/gmail-readonly` access
  - Go 1.24 build with version ldflags
- **`.github/workflows/release.yml`**: Added two new jobs:
  - `snap`: Build and publish to Snap Store (disabled with `if: false` pending personal-files interface approval)
  - `linux-packages`: Trigger APT/RPM repo update via repository dispatch
- **`README.md`**: Comprehensive Linux installation instructions

## Required Secrets (to be added before release)

| Secret | Purpose |
|--------|---------|
| `SNAPCRAFT_STORE_CREDENTIALS` | Publish to Snap Store |
| `LINUX_PACKAGES_DISPATCH_TOKEN` | Trigger linux-packages workflow |

## Notes

- Snap job is disabled (`if: false`) pending personal-files interface approval from Canonical
- Uses `ocli-gmail` as snap name with `gmro` alias

## Test Plan

- [x] `goreleaser check` passes
- [x] `make build` succeeds
- [x] `make test` passes
- [x] `make lint` passes
- [ ] After merge: Verify `.deb`/`.rpm` packages appear in GitHub Release
- [ ] After secrets configured: Verify linux-packages dispatch triggers

Closes #69