### PR TITLE
fix: rename snap from ocli-gmail to ocli-gmail-ro

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ winget install OpenCLICollective.gmail-readonly
 **Snap**
 
 ```bash
-sudo snap install ocli-gmail
+sudo snap install ocli-gmail-ro
 ```
 
 > Note: After installation, the command is available as `gmro`.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: ocli-gmail
+name: ocli-gmail-ro
 base: core22
 version: git
 summary: Read-only command-line interface for Gmail
@@ -30,7 +30,7 @@ plugs:
       - $HOME/.config/gmail-readonly
 
 apps:
-  ocli-gmail:
+  ocli-gmail-ro:
     command: bin/gmro
     plugs:
       - home


### PR DESCRIPTION
## Summary

Rename the snap from `ocli-gmail` to `ocli-gmail-ro` to match the repo naming pattern and clarify that this is specifically the read-only Gmail CLI.

## Changes

- **`snap/snapcraft.yaml`**: Updated `name` and `apps` section
- **`README.md`**: Updated snap install command

## Test Plan

- [x] `goreleaser check` passes
- [x] `make build` succeeds
- [x] `make test` passes