### PR TITLE
ci: fix snap build to use tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,9 +253,12 @@ jobs:
   snap:
     needs: goreleaser
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ env.TAG }}
           fetch-depth: 0
 
       - name: Build snap


### PR DESCRIPTION
## Summary
- Add TAG env var to snap job
- Checkout at tag ref so git describe finds the version

Fixes #76